### PR TITLE
[codex] Cover stale traffic group member assignment

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/TrafficGroupSystemSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/TrafficGroupSystemSourceTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace TrafficLightsEnhancement.Ecs.Tests;
+
+public sealed class TrafficGroupSystemSourceTests
+{
+    [Fact]
+    public void Add_junction_to_group_reuses_stale_null_group_member_component()
+    {
+        string source = File.ReadAllText(GetTrafficGroupSystemPath());
+        string addJunctionSource = ExtractMethod(source, "public bool AddJunctionToGroup");
+        string canAssignSource = ExtractMethod(source, "private static bool CanAssignTrafficGroupMember");
+        string setOrAddSource = ExtractMethod(source, "private static void SetOrAddTrafficGroupMember");
+
+        Assert.Contains("SetOrAddTrafficGroupMember(EntityManager, junctionEntity, member)", addJunctionSource);
+        Assert.DoesNotContain("EntityManager.AddComponentData(junctionEntity, member)", addJunctionSource);
+        Assert.Contains(
+            "return existingMember.m_GroupEntity == Entity.Null",
+            canAssignSource);
+        Assert.Matches(
+            new Regex(
+                @"if\s*\(\s*entityManager\.HasComponent<TrafficGroupMember>\(junctionEntity\)\s*\).*?entityManager\.SetComponentData\(junctionEntity,\s*member\)",
+                RegexOptions.Singleline),
+            setOrAddSource);
+    }
+
+    private static string GetTrafficGroupSystemPath()
+    {
+        string baseDirectory = AppContext.BaseDirectory;
+        string path = Path.GetFullPath(Path.Combine(
+            baseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "TrafficLightsEnhancement",
+            "Systems",
+            "TrafficGroupSystem.cs"));
+
+        Assert.True(File.Exists(path), $"Could not find TrafficGroupSystem.cs at {path}");
+        return path;
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find method signature: {signature}");
+
+        int braceStart = source.IndexOf('{', start);
+        Assert.True(braceStart >= 0, $"Could not find method body: {signature}");
+
+        int depth = 0;
+        for (int i = braceStart; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, i - start + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not parse method body: {signature}");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds ECS-test-project regression coverage for issue #84's stale/null TrafficGroupMember assignment path.
- Guards that AddJunctionToGroup routes assignment through SetOrAddTrafficGroupMember instead of unconditionally adding a duplicate component.
- Also guards that CanAssignTrafficGroupMember admits an existing TrafficGroupMember when m_GroupEntity == Entity.Null.
- Keeps production code unchanged because main already contains the SetOrAddTrafficGroupMember fix.

## Validation
- dotnet test TrafficLightsEnhancement.Tests/TrafficLightsEnhancement.Tests.csproj --filter FullyQualifiedName~TrafficGroupSystemSourceTests --no-restore (RED check after temporarily restoring the old unconditional AddComponentData path; failed as expected)
- dotnet test TrafficLightsEnhancement.Ecs.Tests/TrafficLightsEnhancement.Ecs.Tests.csproj --filter FullyQualifiedName~TrafficGroupSystemSourceTests --no-restore (RED check after temporarily changing the stale/null admission branch to return false; failed as expected)
- dotnet test TrafficLightsEnhancement.Ecs.Tests/TrafficLightsEnhancement.Ecs.Tests.csproj --filter FullyQualifiedName~TrafficGroupSystemSourceTests --no-restore
- dotnet test TrafficLightsEnhancement.Ecs.Tests/TrafficLightsEnhancement.Ecs.Tests.csproj --no-restore

Closes #84