### PR TITLE
[codex] audit inherited documentation behavior claims

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,7 +47,7 @@ If available, attach `Player.log` and relevant files from:
 %UserProfile%\AppData\LocalLow\Colossal Order\Cities Skylines II\
 ```
 
-For Tram Signal Priority issues, note whether the diagnostics option was enabled and attach the JSONL trace if relevant.
+For Transit Signal Priority issues, note whether the diagnostics option was enabled and attach the JSONL trace if relevant.
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/playtest_observation.md
+++ b/.github/ISSUE_TEMPLATE/playtest_observation.md
@@ -25,7 +25,7 @@ Describe what you think the mod should do in this situation, if known.
 
 ## Diagnostics
 
-For Tram Signal Priority or bus diagnostics, include:
+For Transit Signal Priority diagnostics, include:
 
 - Selected entity:
 - Signal state/current group/next group:

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> Currently, the mod only supports three-way and four-way junctions. Junctions of other types will offer fewer options in the mod.
+> The available controls depend on junction topology. Vanilla and Custom Phases are offered broadly, while predefined advanced modes are hidden unless the selected junction meets their topology requirements. For example, Protected Left/Right-Turns require a four-approach junction with straight-through approaches, and split-phasing variants are unavailable on rail/track junctions or junctions with more than seven connected edges.
 
 > [!TIP]
 > Most controls change the sequencing or grouping of signals. Dynamic mode and Transit Signal Priority can also affect phase selection or timing within their configured limits.
@@ -23,7 +23,7 @@ TLE Extended introduces advanced traffic light controls for Cities: Skylines II,
 | Allow Turning on Red | Allow vehicles to turn left (in LHT) or right (in RHT) when the signal is red. |
 | Give Way to Oncoming Vehicles<br>(Only for vanilla signals) | Require vehicles to give way to oncoming traffic when turning.<br>Note: Although drivers are required to give way, their aggressive behavior may reduce the effectiveness of this option at busy junctions. |
 | Exclusive Pedestrian Phase | A dedicated phase for pedestrian crossings, stopping all vehicular traffic. |
-| Pedestrian Phase Duration | Sets the duration of the green light for pedestrians.<br>Only available when the "Exclusive Pedestrian Phase" option is enabled.<br>Note: Pedestrian traffic lights are not "smart" and will not extend the green signal. |
+| Pedestrian Phase Duration | Multiplies the base green-light duration for the exclusive pedestrian phase.<br>Only available when the "Exclusive Pedestrian Phase" option is enabled.<br>Note: Pedestrian traffic lights are not "smart" and will not extend the green signal. |
 
 ## Transit Signal Priority
 
@@ -36,7 +36,7 @@ Transit Signal Priority is configured per intersection. The panel provides separ
 
 TSP is intended to reduce avoidable transit delay, not to force every signal to flip immediately. Tram requests have higher priority than bus requests and can use stronger preemption behavior. Bus requests are softer: they can extend a compatible green or select their target group at normal transition points, while stop-aware suppression avoids holding cross traffic for buses that are boarding or likely stopping before the signal.
 
-Bus TSP has been playtested as a release-ready soft-priority feature on bus-only lanes, mixed lanes, vanilla signals, split phasing, protected turns, tram corridors, and exclusive pedestrian phases. Dedicated bus lanes usually produce cleaner detection. Mixed-lane buses are supported, but the detector is more conservative when the bus stop relationship or lane-change target is unclear.
+Bus TSP is implemented as a conservative soft-priority feature and repo notes record release-readiness playtesting on bus-only lanes, mixed lanes, vanilla signals, split phasing, protected turns, tram corridors, and exclusive pedestrian phases. Dedicated bus lanes usually produce cleaner detection. Mixed-lane buses are supported, but the detector is more conservative when the bus stop relationship or lane-change target is unclear.
 
 Traffic groups and TSP are intentionally treated as incompatible controls. When an intersection is part of a TLE traffic group, local TSP is suspended so group coordination and green-wave timing remain authoritative. The intersection's saved TSP settings are preserved and can take effect again if the intersection is removed from the group.
 
@@ -98,11 +98,14 @@ Common bus decisions:
 
 ## How To Use
 
+> [!NOTE]
+> The screenshots below are inherited from the original guide and are tracked for refresh in issue #91. They have not been replaced here because no current TLE Extended screenshots are checked into the repository.
+
 1. Open the Roads Tool, switch to the Road Services tab, and select "Traffic Lights"
 
 ![Screenshot 2023-12-10 102831](https://github.com/primeinc/Cities2-Various-Mods/assets/80482978/de6a9184-d340-4371-82c9-ef6731a69630)
 
-2. A small window should appear in the top-left corner of your screen. Move your cursor to any existing junction and press the left mouse button
+2. The TLE panel should appear from the floating Traffic Lights Enhancement button. Move your cursor to an existing signalized junction and press the left mouse button
 
 ![Screenshot 2023-12-10 103024](https://github.com/primeinc/Cities2-Various-Mods/assets/80482978/c0beae47-9175-4a31-aad4-ea169f81e1e7)
 
@@ -112,5 +115,5 @@ Common bus decisions:
 
 4. Save the selected junction. It should now operate with the chosen mode and per-intersection options.
 
-[^1]: Advanced Split Phasing and Protected Left/Right-Turns are unavailable at complex junctions, such as those with tram tracks.
+[^1]: Advanced Split Phasing and Protected Left/Right-Turns are topology-gated in the panel. Rail/track junctions and very complex junctions expose fewer predefined modes; Custom Phases remains available for manual configuration.
 [^2]: This advanced split phasing handles traffic light groups dynamically, considering traffic direction and neighboring lane groups.

--- a/docs/inherited-documentation-audit.md
+++ b/docs/inherited-documentation-audit.md
@@ -1,20 +1,25 @@
 # Inherited Documentation Accuracy Audit
 
 This note records the issue #92 documentation accuracy pass. The goal was to
-check inherited user-facing claims against current repo evidence, not to rewrite
-the docs for style.
+check inherited current-facing claims against current repo evidence, not to
+rewrite the docs for style.
 
-## Scope Scanned
-
-- `README.md`
-- `GUIDE.md`
-- Maintainer docs under `docs/`, with extra attention to TSP, custom phases,
-  dynamic mode, traffic groups, localization, diagnostics, and save format
-- `.github` issue and pull request templates
-
-Historical implementation plans under `docs/superpowers/specs/` were treated as
+Historical implementation plans under `docs/superpowers/specs/` are treated as
 planning records. They were scanned for conflicting current-facing claims, but
 not rewritten as live user documentation.
+
+## Broad Scan Matrix
+
+| Area | Files checked | Result |
+| --- | --- | --- |
+| Project identity and release status | `README.md`, `BUILD.md`, `ROADMAP.md` | Current wording matches the repo posture: TLE Extended is source-built/local for now, not publicized on Paradox Mods, while retaining inherited `C2VM.TrafficLightsEnhancement` assembly/root identifiers for compatibility. |
+| Player guide | `GUIDE.md` | One inherited topology claim and one ambiguous pedestrian-duration description were stale; both were updated. The old screenshots are flagged but not replaced in this pass. |
+| Custom phases and dynamic mode | `docs/custom-phase-data-flow.md`, `docs/dynamic-mode.md`, `docs/custom-state-machine-no-tsp-regression.md`, `docs/custom-phase-selection-extraction.md` | Claims match the current architecture docs and code shape: custom phases use `CustomTrafficLights`, `CustomPhaseData`, `EdgeGroupMask`, and `SubLaneGroupMask`; dynamic durations are signal update ticks despite `s` UI labels; pure extraction remains a recommendation rather than completed work. |
+| Traffic groups | `docs/traffic-groups.md`, `GUIDE.md`, `docs/dynamic-mode.md`, `docs/custom-phase-data-flow.md` | Current docs now consistently say local TSP is suspended for every grouped junction, including the leader, while saved settings are preserved. |
+| TSP, diagnostics, and bus priority | `GUIDE.md`, `ROADMAP.md`, `docs/tsp-architecture.md`, `docs/tsp-diagnostics-audit.md`, `docs/transit-signal-priority-bus-research.md` | Stale tram-only wording was replaced where it was current-facing. Bus priority is documented as a conservative soft MVP backed by existing tests and playtest notes, not by a fresh playtest from this audit. |
+| Save format and migration | `docs/save-format-contract.md`, `docs/serialization-and-migration-audit.md`, `README.md` | Current docs match the additive TSP-save posture, inherited serializer coverage, grouped-intersection TSP suspension, and downgrade warning. |
+| Localization and user-facing text | `docs/localization-workflow.md`, `docs/localization-resource-audit.md`, `docs/mod-option-descriptions-audit.md`, `TrafficLightsEnhancement/Locale.json` | Current docs match the active `Locale.json` path and the test-backed `Options.OPTION_DESCRIPTION[...]` convention. Legacy `.tooltip` keys remain intentionally preserved. |
+| GitHub templates and agent docs | `.github/ISSUE_TEMPLATE/*.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/copilot-instructions.md`, `AGENTS.md`, `docs/agent-workflow.md` | Templates are consistent with current project workflow after replacing remaining current-facing tram-only diagnostics wording. Client-specific agent shims correctly defer to `AGENTS.md`. |
 
 ## Verified From Current Code Or Repo Contracts
 
@@ -30,6 +35,10 @@ not rewritten as live user documentation.
 - Pedestrian Phase Duration is a multiplier. The UI uses the
   `CustomPedestrianDurationMultiplier` label and `x` suffix, and the runtime
   multiplies the base pedestrian green duration.
+- The dynamic/custom phase docs match the current model: phase indexes are
+  signal group indexes minus one, edge/sub-lane masks encode served movements,
+  dynamic timing compares raw update ticks, and `CustomStateMachine` still owns
+  mutable timer/state transitions.
 - TSP tram and bus controls are separate source toggles. Disabling one source
   leaves the saved `TransitSignalPrioritySettings` component in place when the
   other source remains enabled; disabling both removes it.
@@ -42,8 +51,12 @@ not rewritten as live user documentation.
 - Traffic-group members, including leaders, cannot toggle or run local TSP
   while grouped. Saved TSP settings are preserved for use after removal from the
   group.
-- The save-format docs match the current serialized TSP source flags and
-  component-removal behavior after both TSP sources are disabled.
+- The save-format docs match the current serialized TSP source flags,
+  component-removal behavior after both TSP sources are disabled, and inherited
+  traffic-group/custom-phase compatibility posture.
+- The localization docs match the current runtime path: `Mod.OnLoad()` loads
+  `Locale.json` through `LocaleHelper`, React UI code uses `useLocalization()`,
+  and source tests guard visible option descriptions.
 
 ## Updated In This Pass
 
@@ -56,8 +69,12 @@ not rewritten as live user documentation.
   issue #91.
 - `docs/tsp-architecture.md`, `docs/tsp-diagnostics-audit.md`, and
   `docs/save-format-contract.md`: corrected stale TSP/public-car/bus wording.
-- `.github/ISSUE_TEMPLATE/bug_report.md`: updated the diagnostics prompt from
-  Tram Signal Priority to Transit Signal Priority.
+- `.github/ISSUE_TEMPLATE/bug_report.md` and
+  `.github/ISSUE_TEMPLATE/playtest_observation.md`: updated diagnostics prompts
+  from tram-only wording to Transit Signal Priority.
+- `docs/inherited-documentation-audit.md`: expanded the audit trail beyond TSP
+  so future maintainers can see which inherited documentation areas were
+  checked and which still need in-game evidence.
 
 ## Still Requiring In-Game Evidence Or Follow-Up
 

--- a/docs/inherited-documentation-audit.md
+++ b/docs/inherited-documentation-audit.md
@@ -1,0 +1,74 @@
+# Inherited Documentation Accuracy Audit
+
+This note records the issue #92 documentation accuracy pass. The goal was to
+check inherited user-facing claims against current repo evidence, not to rewrite
+the docs for style.
+
+## Scope Scanned
+
+- `README.md`
+- `GUIDE.md`
+- Maintainer docs under `docs/`, with extra attention to TSP, custom phases,
+  dynamic mode, traffic groups, localization, diagnostics, and save format
+- `.github` issue and pull request templates
+
+Historical implementation plans under `docs/superpowers/specs/` were treated as
+planning records. They were scanned for conflicting current-facing claims, but
+not rewritten as live user documentation.
+
+## Verified From Current Code Or Repo Contracts
+
+- Junction support is topology-gated, not limited to only three-way and
+  four-way junctions. `UISystem.UIBIndings.cs` always exposes Vanilla and Custom
+  Phases for selected signalized junctions, while `PredefinedPatternsProcessor`
+  hides predefined advanced modes when topology checks fail.
+- Protected Left/Right-Turns require a four-approach junction whose approaches
+  have straight-through car/public-car/track lanes, and they are rejected for
+  track-turn cases.
+- Split-phasing variants are rejected for rail/track junctions and for
+  junctions with more than seven connected edges.
+- Pedestrian Phase Duration is a multiplier. The UI uses the
+  `CustomPedestrianDurationMultiplier` label and `x` suffix, and the runtime
+  multiplies the base pedestrian green duration.
+- TSP tram and bus controls are separate source toggles. Disabling one source
+  leaves the saved `TransitSignalPrioritySettings` component in place when the
+  other source remains enabled; disabling both removes it.
+- Bus priority is represented internally as `TspSource.PublicCar`, has lower
+  source priority than tram/track requests, and does not use the tram-only
+  aggressive preemption path.
+- TSP diagnostics are off by default, gated by
+  `Settings.m_ShowTransitSignalPriorityDiagnostics`, and exposed through
+  selected-intersection rows and optional JSONL trace output.
+- Traffic-group members, including leaders, cannot toggle or run local TSP
+  while grouped. Saved TSP settings are preserved for use after removal from the
+  group.
+- The save-format docs match the current serialized TSP source flags and
+  component-removal behavior after both TSP sources are disabled.
+
+## Updated In This Pass
+
+- `GUIDE.md`: replaced the inherited three-way/four-way limitation with
+  topology-gated wording.
+- `GUIDE.md`: clarified Pedestrian Phase Duration as a multiplier.
+- `GUIDE.md`: softened the bus-priority playtest claim to cite repo notes
+  rather than presenting fresh verification from this audit.
+- `GUIDE.md`: added a note that the inherited screenshots remain tracked by
+  issue #91.
+- `docs/tsp-architecture.md`, `docs/tsp-diagnostics-audit.md`, and
+  `docs/save-format-contract.md`: corrected stale TSP/public-car/bus wording.
+- `.github/ISSUE_TEMPLATE/bug_report.md`: updated the diagnostics prompt from
+  Tram Signal Priority to Transit Signal Priority.
+
+## Still Requiring In-Game Evidence Or Follow-Up
+
+- Current GUIDE screenshots were not replaced because no current TLE Extended
+  screenshots are checked into the repository. This remains tracked by issue
+  #91.
+- Bus-priority release-readiness and mixed-lane behavior are supported by
+  current repo playtest notes and policy tests, but this audit did not perform a
+  fresh in-game playtest.
+- The How To Use flow was checked against current UI/tool code, but the exact
+  current in-game visual flow should be confirmed when refreshing screenshots.
+- Compatibility with the current Cities: Skylines II version still needs the
+  normal release-readiness check before any public release, as already stated in
+  `README.md`.

--- a/docs/save-format-contract.md
+++ b/docs/save-format-contract.md
@@ -141,8 +141,8 @@ TLE Extended should preserve these assumptions while in drop-in mode:
 - Existing saves from supported TLE versions load without user action.
 - Existing TLE intersections without `TransitSignalPrioritySettings` behave as
   non-TSP intersections.
-- TSP is additive per junction; disabling TSP removes the settings component and
-  leaves inherited TLE data intact.
+- TSP is additive per junction; disabling both source controls removes the
+  settings component and leaves inherited TLE data intact.
 - Grouped intersections do not run local TSP, including the group leader. Any
   future group-wide TSP behavior needs a new explicit design before save fields
   are added.

--- a/docs/tsp-architecture.md
+++ b/docs/tsp-architecture.md
@@ -28,7 +28,7 @@ Key files:
 - [`TransitSignalPriorityRuntime.cs`](../TrafficLightsEnhancement.Logic/Tsp/TransitSignalPriorityRuntime.cs) converts normalized settings plus lane classification into a `TspRequest`. It can emit `TspSource.Track` or `TspSource.PublicCar` when the matching source flag is enabled.
 - [`TspSourcePriority.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspSourcePriority.cs) is the single source of truth for source ordering. Track requests outrank public-car/bus requests, and equal-priority requests use strength as the tiebreaker.
 - [`EarlyApproachDetection.cs`](../TrafficLightsEnhancement.Logic/Tsp/EarlyApproachDetection.cs) contains pure helper policy for approach-lane resolution, tram-sample probing, early-vs-petitioner selection, and connected-edge fallback diagnostics.
-- [`TspDecisionEngine.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspDecisionEngine.cs) combines and scores requests. `CombineRequests()` selects the strongest track request; `SelectNextPhase()` can extend a current track-serving phase or bias selection toward track-serving phases.
+- [`TspDecisionEngine.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspDecisionEngine.cs) combines and scores requests. `CombineRequests()` selects the strongest eligible request using source priority first, then strength; `SelectNextPhase()` can extend a current phase that serves the request or bias selection toward a phase serving that source.
 - [`TspOverrideEngine.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspOverrideEngine.cs) applies a selected TSP request to a base phase or signal group choice. It owns `TspSelectionReason` and `TspOverrideSelection`.
 - [`TspPreemptionPolicy.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspPreemptionPolicy.cs) owns request latching, current-group hold, aggressive preemption, minimum-green override, and exclusive-pedestrian protection.
 - [`TspStatusFormatter.cs`](../TrafficLightsEnhancement.Logic/Tsp/TspStatusFormatter.cs) converts request state into UI-facing status labels.
@@ -157,7 +157,7 @@ The toggle path is also in `UISystem.UIBIndings.cs`:
 
 - The UI calls `toggleTransitSignalPriorityForTrams(...)` and `toggleTransitSignalPriorityForBuses(...)`.
 - The C# triggers `ToggleTransitSignalPriorityForTrams(...)` and `ToggleTransitSignalPriorityForBuses(...)` create or update `TransitSignalPrioritySettings` when enabled.
-- Disabling TSP removes `TransitSignalPrioritySettings` from the selected entity and marks it updated.
+- Disabling the last enabled TSP source removes `TransitSignalPrioritySettings` from the selected entity and marks it updated.
 - Intersections in TLE traffic groups cannot toggle local TSP. Runtime TSP is suspended for every group member, including the leader, so group coordination and green-wave timing remain authoritative. Saved TSP settings are preserved and can resume if the intersection leaves the group.
 
 Diagnostics are off by default. The mod option is `Settings.m_ShowTransitSignalPriorityDiagnostics`; `GetMainPanel()` only builds diagnostics when that option is true. `UISystem.SimulationUpdate()` also only auto-refreshes the selected panel for diagnostics when the same option is enabled.
@@ -195,7 +195,7 @@ TSP pure logic is covered by xUnit tests in [`TrafficLightsEnhancement.Tests/Tsp
 
 - [`TspPolicyTests.cs`](../TrafficLightsEnhancement.Tests/Tsp/TspPolicyTests.cs) covers availability, grouped-intersection policy, default settings, persisted-value detection, normalization/clamping, approach-index policy, and pedestrian mask bounds.
 - [`TspEarlyDetectionTests.cs`](../TrafficLightsEnhancement.Tests/Tsp/TspEarlyDetectionTests.cs) covers lane resolution, indexed probe precedence, movement suppression, early-over-petitioner selection, connected-edge fallback helpers, and upstream/path-node helpers.
-- [`TspDecisionEngineTests.cs`](../TrafficLightsEnhancement.Tests/Tsp/TspDecisionEngineTests.cs) covers track-only requests, public-car non-participation, null/empty handling, extension rules, override behavior, latching/expiry, hold policy, aggressive preemption, and active pedestrian protection.
+- [`TspDecisionEngineTests.cs`](../TrafficLightsEnhancement.Tests/Tsp/TspDecisionEngineTests.cs) covers track and public-car requests, null/empty handling, extension rules, override behavior, latching/expiry, hold policy, aggressive preemption, and active pedestrian protection.
 - [`TspStatusFormatterTests.cs`](../TrafficLightsEnhancement.Tests/Tsp/TspStatusFormatterTests.cs) covers status label formatting.
 
 UI-facing behavior also has Node tests in [`TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs`](../TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs), including panel state, diagnostics gating, trace writing, toggling, cleanup, and serialization expectations.

--- a/docs/tsp-diagnostics-audit.md
+++ b/docs/tsp-diagnostics-audit.md
@@ -69,7 +69,7 @@ enabled track-capable standalone TSP setting -> scan rail transit lanes for the 
 
 Disabling TSP from the UI removes the settings component, which still avoids the
 scan for users who have no TSP-enabled intersections. The narrower gate also
-protects against stale disabled settings and future public-car-only settings.
+protects against stale disabled settings and bus/public-car-only settings.
 
 Bus indexing is built when diagnostics or bus priority need bus samples. With
 diagnostics disabled and bus priority off, panel-only bus debug work should not


### PR DESCRIPTION
*Written by Codex.*

## Summary

- Replace the inherited GUIDE junction-support claim with topology-gated wording verified against current UI/pattern gating code.
- Clarify TSP, bus-priority, pedestrian-duration, diagnostics, and save-format wording where current code or repo contracts contradicted stale inherited text.
- Broaden `docs/inherited-documentation-audit.md` into an audit trail across README, BUILD, ROADMAP, GUIDE, maintainer docs, localization docs, save docs, traffic-group docs, and GitHub templates.
- Update both bug and playtest issue templates from tram-only diagnostics wording to Transit Signal Priority.
- Record that GUIDE screenshots remain inherited/stale and are tracked separately by #91.

## Verification

- `git diff --check`
- `git diff --check origin/main...HEAD`
- `rg -n "For Tram Signal Priority|Tram Signal Priority or bus|only supports three-way|only supports.*four-way|three-way and four-way" README.md BUILD.md GUIDE.md ROADMAP.md docs .github` returned no current-facing stale phrase matches.

Closes #92.