### PR TITLE
[codex] document squash merge workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,6 @@ See `docs/agent-workflow.md` for why the repo-local skills exist, what each skil
 
 When an AI agent authors GitHub-facing text, including pull request bodies, pull request comments, or review comments, prefix the text with `*Written by <AgentName>.*` using that agent's actual name, such as `Codex`, `Claude`, or `Gemini`.
 
+Pull requests should be squash-merged into `main`. Keep individual branch commits useful for review, but expect the PR title/body and final squash commit to carry the durable history. Delete merged head branches after merge unless a maintainer asks to keep one for follow-up work.
+
 Keep changes scoped and preserve user work in the current tree. This mod intentionally keeps `C2VM.TrafficLightsEnhancement` assembly/root namespace identifiers for compatibility with existing Traffic Lights Enhancement saves and configured intersections.

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -26,6 +26,10 @@ Agents implementing features, bugfixes, or GitHub issues should work on a dedica
 
 When an AI agent writes GitHub-facing text for this repository, the text should start with `*Written by <AgentName>.*` using the agent's actual name. This applies to pull request bodies, pull request comments, and review comments, so humans can distinguish automated agent notes from maintainer-written text.
 
+## Pull Request Integration
+
+Pull requests should be squash-merged into `main`, and merged head branches should be deleted after merge unless a maintainer asks to keep one. Keep local branch commits useful for review and iteration, but treat the PR title/body, linked issues, review discussion, and final squash commit as the durable project history.
+
 ## Maintenance Rules
 
 - Keep skill bodies concise and procedural; move durable project knowledge into normal docs when humans should read it too.


### PR DESCRIPTION
*Written by Codex.*

## Summary

- Document that TLE Extended PRs should be squash-merged into `main`.
- Note that branch commits are for review/iteration, while PRs and final squash commits carry durable history.
- Record the expectation to delete merged head branches unless a maintainer asks to keep one.

## Verification

- `git diff --check`
- Confirmed repository settings allow squash merge only and auto-delete head branches.
- Confirmed the default-branch ruleset allows only squash merge methods.