### PR TITLE
[codex] Fix bicycle mask phase swaps

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/CustomPhaseUtilsTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/CustomPhaseUtilsTests.cs
@@ -1,0 +1,26 @@
+using C2VM.TrafficLightsEnhancement.Components;
+using C2VM.TrafficLightsEnhancement.Utils;
+using Xunit;
+
+namespace TrafficLightsEnhancement.Ecs.Tests;
+
+public sealed class CustomPhaseUtilsTests
+{
+    [Fact]
+    public void SwapBit_moves_edge_bicycle_go_and_yield_phase_bits()
+    {
+        var phase = new EdgeGroupMask
+        {
+            m_Bicycle =
+            {
+                m_GoGroupMask = 0b_0000_1000,
+                m_YieldGroupMask = 0b_0000_0010
+            }
+        };
+
+        CustomPhaseUtils.SwapBit(ref phase, 3, 1);
+
+        Assert.Equal((ushort)0b_0000_0010, phase.m_Bicycle.m_GoGroupMask);
+        Assert.Equal((ushort)0b_0000_1000, phase.m_Bicycle.m_YieldGroupMask);
+    }
+}

--- a/TrafficLightsEnhancement/Utils/CustomPhaseUtils.cs
+++ b/TrafficLightsEnhancement/Utils/CustomPhaseUtils.cs
@@ -189,6 +189,7 @@ public struct CustomPhaseUtils
         TurnSwapBit(ref phase.m_PublicCar, index1, index2);
         TurnSwapBit(ref phase.m_Track, index1, index2);
         SignalSwapBit(ref phase.m_Pedestrian, index1, index2);
+        SignalSwapBit(ref phase.m_Bicycle, index1, index2);
     }
 
     public static void SwapBit(ref SubLaneGroupMask phase, int index1, int index2)


### PR DESCRIPTION
﻿*Written by Codex.*

## Summary

Fixes #97 by moving the edge-level bicycle signal mask whenever custom phase mask bits are swapped.

`CustomPhaseUtils.SwapBit(ref EdgeGroupMask...)` already moved car, public-car, track, and pedestrian masks. This adds the missing bicycle signal swap so phase reorder/remove keeps bicycle service attached to the intended phase.

## Tests

- Red/green worker check: focused test failed before the fix with bicycle go mask still on the old bit.
- `dotnet test TrafficLightsEnhancement.Ecs.Tests\TrafficLightsEnhancement.Ecs.Tests.csproj --filter FullyQualifiedName~CustomPhaseUtilsTests.SwapBit_moves_edge_bicycle_go_and_yield_phase_bits`
- `dotnet test TrafficLightsEnhancement.Ecs.Tests\TrafficLightsEnhancement.Ecs.Tests.csproj`
