### PR TITLE
[codex] Hide unsupported options on complex intersections

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/PredefinedPatternOptionSupportSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/PredefinedPatternOptionSupportSourceTests.cs
@@ -1,107 +1,82 @@
-using System;
-using System.IO;
+using C2VM.TrafficLightsEnhancement.Components;
+using C2VM.TrafficLightsEnhancement.Systems.TrafficLightSystems.Initialisation;
 using Xunit;
 
 namespace TrafficLightsEnhancement.Ecs.Tests;
 
 public sealed class PredefinedPatternOptionSupportSourceTests
 {
-    [Fact]
-    public void Extra_options_share_topology_gate_with_simple_predefined_patterns()
+    [Theory]
+    [InlineData(7, false, true)]
+    [InlineData(8, false, false)]
+    [InlineData(4, true, false)]
+    public void Extra_options_are_supported_only_on_non_train_topologies_with_at_most_seven_edges(
+        int edgeCount,
+        bool hasTrainTrack,
+        bool expected)
     {
-        string source = File.ReadAllText(GetRepoPath(
-            "TrafficLightsEnhancement",
-            "Systems",
-            "TrafficLightSystems",
-            "Initialisation",
-            "PredefinedPatternsProcessor.cs"));
-        string supportMethod = ExtractMethod(source, "public static bool AreExtraOptionsSupported");
+        bool actual = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeCount, hasTrainTrack);
 
-        Assert.Contains("!HasTrainTrack(edgeInfoArray)", supportMethod);
-        Assert.Contains("edgeInfoArray.Length <= 7", supportMethod);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Exclusive_pedestrian_option_is_not_supported_on_highway_topologies(
+        bool hasHighwayLane,
+        bool expected)
+    {
+        bool actual = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(hasHighwayLane);
+
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
-    public void Split_phasing_protected_left_uses_protected_turn_topology_gate()
+    public void Clear_extra_options_removes_only_option_flags()
     {
-        string source = File.ReadAllText(GetRepoPath(
-            "TrafficLightsEnhancement",
-            "Systems",
-            "TrafficLightSystems",
-            "Initialisation",
-            "PredefinedPatternsProcessor.cs"));
-        string validPatternSource = ExtractMethod(source, "public static bool IsValidPattern");
+        const CustomTrafficLights.Patterns pattern =
+            CustomTrafficLights.Patterns.SplitPhasingProtectedLeft |
+            CustomTrafficLights.Patterns.ExclusivePedestrian |
+            CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn |
+            CustomTrafficLights.Patterns.CentreTurnGiveWay |
+            CustomTrafficLights.Patterns.SmartPhaseSelection;
 
-        Assert.Contains("case (uint)CustomTrafficLights.Patterns.SplitPhasingProtectedLeft:", validPatternSource);
-        Assert.Contains("IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.ProtectedCentreTurn)", validPatternSource);
+        CustomTrafficLights.Patterns actual = PredefinedPatternsProcessor.ClearExtraOptions(pattern);
+
+        Assert.Equal(
+            CustomTrafficLights.Patterns.SplitPhasingProtectedLeft |
+            CustomTrafficLights.Patterns.SmartPhaseSelection,
+            actual);
+    }
+
+    [Theory]
+    [InlineData(4, true, true)]
+    [InlineData(3, false, false)]
+    [InlineData(8, true, false)]
+    public void Protected_turn_topology_requires_four_straight_ways(
+        int edgeCount,
+        bool includeStraightTrafficOnEveryEdge,
+        bool expected)
+    {
+        int straightWays = includeStraightTrafficOnEveryEdge ? edgeCount : 0;
+
+        bool actual = PredefinedPatternsProcessor.IsProtectedCentreTurnTopology(
+            edgeCount,
+            straightWays,
+            hasTurningTrackLane: false);
+
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
-    public void Main_panel_hides_extra_options_when_topology_gate_fails()
+    public void Protected_turn_topology_rejects_turning_track_lanes()
     {
-        string source = File.ReadAllText(GetRepoPath(
-            "TrafficLightsEnhancement",
-            "Systems",
-            "UI",
-            "UISystem.UIBIndings.cs"));
-        string mainPanelSource = ExtractMethod(source, "protected string GetMainPanel");
+        bool actual = PredefinedPatternsProcessor.IsProtectedCentreTurnTopology(
+            edgeCount: 4,
+            straightWays: 4,
+            hasTurningTrackLane: true);
 
-        Assert.Contains("PredefinedPatternsProcessor.AreExtraOptionsSupported(m_EdgeInfoDictionary[m_SelectedEntity])", mainPanelSource);
-        Assert.DoesNotContain("bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault && !hasTrainTrack", mainPanelSource);
-    }
-
-    [Fact]
-    public void Initialization_clears_extra_options_when_topology_gate_fails()
-    {
-        string source = File.ReadAllText(GetRepoPath(
-            "TrafficLightsEnhancement",
-            "Systems",
-            "TrafficLightSystems",
-            "Initialisation",
-            "PatchedTrafficLightInitializationSystem.cs"));
-
-        Assert.Contains("bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray)", source);
-        Assert.Contains("customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExtraOptions(pattern))", source);
-    }
-
-    private static string GetRepoPath(params string[] segments)
-    {
-        string path = AppContext.BaseDirectory;
-        for (int i = 0; i < 4; i++)
-        {
-            path = Path.GetDirectoryName(path) ?? throw new DirectoryNotFoundException(path);
-        }
-
-        path = Path.Combine(path, Path.Combine(segments));
-        Assert.True(File.Exists(path), $"Could not find expected repo file at {path}");
-        return path;
-    }
-
-    private static string ExtractMethod(string source, string signature)
-    {
-        int start = source.IndexOf(signature, StringComparison.Ordinal);
-        Assert.True(start >= 0, $"Could not find method signature: {signature}");
-
-        int braceStart = source.IndexOf('{', start);
-        Assert.True(braceStart >= 0, $"Could not find method body: {signature}");
-
-        int depth = 0;
-        for (int i = braceStart; i < source.Length; i++)
-        {
-            if (source[i] == '{')
-            {
-                depth++;
-            }
-            else if (source[i] == '}')
-            {
-                depth--;
-                if (depth == 0)
-                {
-                    return source.Substring(start, i - start + 1);
-                }
-            }
-        }
-
-        throw new InvalidOperationException($"Could not parse method body: {signature}");
+        Assert.False(actual);
     }
 }

--- a/TrafficLightsEnhancement.Ecs.Tests/PredefinedPatternOptionSupportSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/PredefinedPatternOptionSupportSourceTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace TrafficLightsEnhancement.Ecs.Tests;
+
+public sealed class PredefinedPatternOptionSupportSourceTests
+{
+    [Fact]
+    public void Extra_options_share_topology_gate_with_simple_predefined_patterns()
+    {
+        string source = File.ReadAllText(GetRepoPath(
+            "TrafficLightsEnhancement",
+            "Systems",
+            "TrafficLightSystems",
+            "Initialisation",
+            "PredefinedPatternsProcessor.cs"));
+        string supportMethod = ExtractMethod(source, "public static bool AreExtraOptionsSupported");
+
+        Assert.Contains("!HasTrainTrack(edgeInfoArray)", supportMethod);
+        Assert.Contains("edgeInfoArray.Length <= 7", supportMethod);
+    }
+
+    [Fact]
+    public void Split_phasing_protected_left_uses_protected_turn_topology_gate()
+    {
+        string source = File.ReadAllText(GetRepoPath(
+            "TrafficLightsEnhancement",
+            "Systems",
+            "TrafficLightSystems",
+            "Initialisation",
+            "PredefinedPatternsProcessor.cs"));
+        string validPatternSource = ExtractMethod(source, "public static bool IsValidPattern");
+
+        Assert.Contains("case (uint)CustomTrafficLights.Patterns.SplitPhasingProtectedLeft:", validPatternSource);
+        Assert.Contains("IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.ProtectedCentreTurn)", validPatternSource);
+    }
+
+    [Fact]
+    public void Main_panel_hides_extra_options_when_topology_gate_fails()
+    {
+        string source = File.ReadAllText(GetRepoPath(
+            "TrafficLightsEnhancement",
+            "Systems",
+            "UI",
+            "UISystem.UIBIndings.cs"));
+        string mainPanelSource = ExtractMethod(source, "protected string GetMainPanel");
+
+        Assert.Contains("PredefinedPatternsProcessor.AreExtraOptionsSupported(m_EdgeInfoDictionary[m_SelectedEntity])", mainPanelSource);
+        Assert.DoesNotContain("bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault && !hasTrainTrack", mainPanelSource);
+    }
+
+    [Fact]
+    public void Initialization_clears_extra_options_when_topology_gate_fails()
+    {
+        string source = File.ReadAllText(GetRepoPath(
+            "TrafficLightsEnhancement",
+            "Systems",
+            "TrafficLightSystems",
+            "Initialisation",
+            "PatchedTrafficLightInitializationSystem.cs"));
+
+        Assert.Contains("bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray)", source);
+        Assert.Contains("customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExtraOptions(pattern))", source);
+    }
+
+    private static string GetRepoPath(params string[] segments)
+    {
+        string path = AppContext.BaseDirectory;
+        for (int i = 0; i < 4; i++)
+        {
+            path = Path.GetDirectoryName(path) ?? throw new DirectoryNotFoundException(path);
+        }
+
+        path = Path.Combine(path, Path.Combine(segments));
+        Assert.True(File.Exists(path), $"Could not find expected repo file at {path}");
+        return path;
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find method signature: {signature}");
+
+        int braceStart = source.IndexOf('{', start);
+        Assert.True(braceStart >= 0, $"Could not find method body: {signature}");
+
+        int depth = 0;
+        for (int i = braceStart; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, i - start + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not parse method body: {signature}");
+    }
+}

--- a/TrafficLightsEnhancement.Ecs.Tests/TrafficGroupSystemSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/TrafficGroupSystemSourceTests.cs
@@ -27,6 +27,16 @@ public sealed class TrafficGroupSystemSourceTests
             setOrAddSource);
     }
 
+    [Fact]
+    public void Propagating_pattern_to_members_marks_each_member_updated()
+    {
+        string source = File.ReadAllText(GetTrafficGroupSystemPath());
+        string propagateSource = ExtractMethod(source, "public void PropagatePatternToMembers");
+
+        Assert.Contains("memberLights.SetPattern(pattern)", propagateSource);
+        Assert.Contains("EntityManager.AddComponentData(memberEntity, default(Updated))", propagateSource);
+    }
+
     private static string GetTrafficGroupSystemPath()
     {
         string baseDirectory = AppContext.BaseDirectory;

--- a/TrafficLightsEnhancement/Systems/TrafficGroupSystem.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficGroupSystem.cs
@@ -1631,6 +1631,11 @@ public partial class TrafficGroupSystem : GameSystemBase
 			
 			
 			CopySubLaneGroupMaskWithLaneTypeMatching(leaderEntity, memberEntity);
+
+			if (!EntityManager.HasComponent<Updated>(memberEntity))
+			{
+				EntityManager.AddComponentData(memberEntity, default(Updated));
+			}
 		}
 
 		int memberCount = members.Length;

--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
@@ -244,18 +244,23 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                 }
                 else
                 {
-                    var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]).AsArray();
-                    bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
-                    var pattern = customTrafficLights.GetPattern();
-                    if (NodeUtils.HasTrainTrack(edgeInfoArray) || !PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, pattern))
-                    {
+                  var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]).AsArray();
+                  bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
+                  bool exclusivePedestrianOptionSupported = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(edgeInfoArray);
+                  var pattern = customTrafficLights.GetPattern();
+                  if (NodeUtils.HasTrainTrack(edgeInfoArray) || !PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, pattern))
+                  {
                         pattern = CustomTrafficLights.Patterns.Vanilla;
                         customTrafficLights.SetPattern(pattern);
                     }
-                    else if (!extraOptionsSupported)
-                    {
-                        customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExtraOptions(pattern));
-                    }
+                  else if (!extraOptionsSupported)
+                  {
+                      customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExtraOptions(pattern));
+                  }
+                  else if (!exclusivePedestrianOptionSupported)
+                  {
+                      customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExclusivePedestrianOption(pattern));
+                  }
                     if (customTrafficLights.GetPatternOnly() == CustomTrafficLights.Patterns.SplitPhasing)
                     {
                         PredefinedPatternsProcessor.SetupSplitPhasing(ref this, connectedEdgeAccessor[i], subLanes, out groupCount, ref trafficLights);

--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
@@ -245,11 +245,16 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                 else
                 {
                     var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]).AsArray();
-                     var pattern = customTrafficLights.GetPattern();
+                    bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
+                    var pattern = customTrafficLights.GetPattern();
                     if (NodeUtils.HasTrainTrack(edgeInfoArray) || !PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, pattern))
                     {
                         pattern = CustomTrafficLights.Patterns.Vanilla;
                         customTrafficLights.SetPattern(pattern);
+                    }
+                    else if (!extraOptionsSupported)
+                    {
+                        customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExtraOptions(pattern));
                     }
                     if (customTrafficLights.GetPatternOnly() == CustomTrafficLights.Patterns.SplitPhasing)
                     {

--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PredefinedPatternsProcessor.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PredefinedPatternsProcessor.cs
@@ -17,12 +17,44 @@ public class PredefinedPatternsProcessor
 
     public static bool AreExtraOptionsSupported(NativeArray<EdgeInfo> edgeInfoArray)
     {
-        return !HasTrainTrack(edgeInfoArray) && edgeInfoArray.Length <= 7;
+        return AreExtraOptionsSupported(edgeInfoArray.Length, HasTrainTrack(edgeInfoArray));
+    }
+
+    public static bool AreExtraOptionsSupported(int edgeCount, bool hasTrainTrack)
+    {
+        return !hasTrainTrack && edgeCount <= 7;
     }
 
     public static CustomTrafficLights.Patterns ClearExtraOptions(CustomTrafficLights.Patterns pattern)
     {
         return pattern & ~ExtraOptionFlags;
+    }
+
+    public static CustomTrafficLights.Patterns ClearExclusivePedestrianOption(CustomTrafficLights.Patterns pattern)
+    {
+        return pattern & ~CustomTrafficLights.Patterns.ExclusivePedestrian;
+    }
+
+    public static bool IsExclusivePedestrianOptionSupported(NativeArray<EdgeInfo> edgeInfoArray)
+    {
+        return IsExclusivePedestrianOptionSupported(HasHighwayLane(edgeInfoArray));
+    }
+
+    public static bool IsExclusivePedestrianOptionSupported(bool hasHighwayLane)
+    {
+        return !hasHighwayLane;
+    }
+
+    public static bool HasHighwayLane(NativeArray<EdgeInfo> edgeInfoArray)
+    {
+        foreach (var edgeInfo in edgeInfoArray)
+        {
+            if (edgeInfo.m_HighwayLaneCount > 0)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static bool IsValidPattern(NativeArray<EdgeInfo> edgeInfoArray, CustomTrafficLights.Patterns pattern)
@@ -45,22 +77,19 @@ public class PredefinedPatternsProcessor
             case (uint)CustomTrafficLights.Patterns.ProtectedCentreTurn:
             {
                 int ways = 0;
+                bool hasTurningTrackLane = false;
                 foreach (var edgeInfo in edgeInfoArray)
                 {
                     if (edgeInfo.m_TrackLaneLeftCount + edgeInfo.m_TrackLaneRightCount > 0)
                     {
-                        return false;
+                        hasTurningTrackLane = true;
                     }
                     if (edgeInfo.m_CarLaneStraightCount + edgeInfo.m_PublicCarLaneStraightCount + edgeInfo.m_TrackLaneStraightCount > 0)
                     {
                         ways++;
                     }
                 }
-                if (ways == 4 && edgeInfoArray.Length == ways)
-                {
-                    return true;
-                }
-                return false;
+                return IsProtectedCentreTurnTopology(edgeInfoArray.Length, ways, hasTurningTrackLane);
             }
             case (uint)CustomTrafficLights.Patterns.SplitPhasingProtectedLeft:
             {
@@ -72,6 +101,11 @@ public class PredefinedPatternsProcessor
                 return true;
             }
         }
+    }
+
+    public static bool IsProtectedCentreTurnTopology(int edgeCount, int straightWays, bool hasTurningTrackLane)
+    {
+        return !hasTurningTrackLane && straightWays == 4 && edgeCount == straightWays;
     }
 
     public static void SetupSplitPhasing(ref InitializeTrafficLightsJob job, DynamicBuffer<ConnectedEdge> connectedEdges, DynamicBuffer<SubLane> subLanes, out int groupCount, ref TrafficLights trafficLights)

--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PredefinedPatternsProcessor.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PredefinedPatternsProcessor.cs
@@ -10,6 +10,21 @@ namespace C2VM.TrafficLightsEnhancement.Systems.TrafficLightSystems.Initialisati
 
 public class PredefinedPatternsProcessor
 {
+    private const CustomTrafficLights.Patterns ExtraOptionFlags =
+        CustomTrafficLights.Patterns.ExclusivePedestrian |
+        CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn |
+        CustomTrafficLights.Patterns.CentreTurnGiveWay;
+
+    public static bool AreExtraOptionsSupported(NativeArray<EdgeInfo> edgeInfoArray)
+    {
+        return !HasTrainTrack(edgeInfoArray) && edgeInfoArray.Length <= 7;
+    }
+
+    public static CustomTrafficLights.Patterns ClearExtraOptions(CustomTrafficLights.Patterns pattern)
+    {
+        return pattern & ~ExtraOptionFlags;
+    }
+
     public static bool IsValidPattern(NativeArray<EdgeInfo> edgeInfoArray, CustomTrafficLights.Patterns pattern)
     {
         if (HasTrainTrack(edgeInfoArray))
@@ -49,11 +64,8 @@ public class PredefinedPatternsProcessor
             }
             case (uint)CustomTrafficLights.Patterns.SplitPhasingProtectedLeft:
             {
-                if (edgeInfoArray.Length > 7)
-                {
-                    return false;
-                }
-                return true;
+                return IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.SplitPhasing)
+                    && IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.ProtectedCentreTurn);
             }
             default:
             {

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
@@ -350,8 +350,8 @@ public partial class UISystem
             bool isCustomPhaseMode = m_CustomTrafficLights.GetPatternOnly() == CustomTrafficLights.Patterns.CustomPhase;
             uint selectedPattern = (uint)m_CustomTrafficLights.GetPattern();
             uint patternOnly = (uint)m_CustomTrafficLights.GetPatternOnly();
-            bool hasTrainTrack = NodeUtils.HasTrainTrack(m_EdgeInfoDictionary[m_SelectedEntity]);
-            bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault && !hasTrainTrack;
+            bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault
+                && PredefinedPatternsProcessor.AreExtraOptionsSupported(m_EdgeInfoDictionary[m_SelectedEntity]);
             bool hasExclusivePedestrian = showOptions && (selectedPattern & (uint)CustomTrafficLights.Patterns.ExclusivePedestrian) != 0;
             bool isTrafficGroupMember = EntityManager.HasComponent<TrafficGroupMember>(m_SelectedEntity);
 

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
@@ -352,7 +352,10 @@ public partial class UISystem
             uint patternOnly = (uint)m_CustomTrafficLights.GetPatternOnly();
             bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault
                 && PredefinedPatternsProcessor.AreExtraOptionsSupported(m_EdgeInfoDictionary[m_SelectedEntity]);
-            bool hasExclusivePedestrian = showOptions && (selectedPattern & (uint)CustomTrafficLights.Patterns.ExclusivePedestrian) != 0;
+            bool exclusivePedestrianOptionSupported = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(m_EdgeInfoDictionary[m_SelectedEntity]);
+            bool hasExclusivePedestrian = showOptions
+                && exclusivePedestrianOptionSupported
+                && (selectedPattern & (uint)CustomTrafficLights.Patterns.ExclusivePedestrian) != 0;
             bool isTrafficGroupMember = EntityManager.HasComponent<TrafficGroupMember>(m_SelectedEntity);
 
             TransitSignalPrioritySettings tspSettings = EntityManager.HasComponent<TransitSignalPrioritySettings>(m_SelectedEntity)
@@ -380,7 +383,8 @@ public partial class UISystem
                 options.Add(new { label = "AllowTurningOnRed", isChecked = (selectedPattern & (uint)CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn) != 0, key = ((uint)CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn).ToString() });
                 if (patternOnly == (uint)CustomTrafficLights.Patterns.Vanilla)
                     options.Add(new { label = "GiveWayToOncomingVehicles", isChecked = (selectedPattern & (uint)CustomTrafficLights.Patterns.CentreTurnGiveWay) != 0, key = ((uint)CustomTrafficLights.Patterns.CentreTurnGiveWay).ToString() });
-                options.Add(new { label = "ExclusivePedestrianPhase", isChecked = hasExclusivePedestrian, key = ((uint)CustomTrafficLights.Patterns.ExclusivePedestrian).ToString() });
+                if (exclusivePedestrianOptionSupported)
+                    options.Add(new { label = "ExclusivePedestrianPhase", isChecked = hasExclusivePedestrian, key = ((uint)CustomTrafficLights.Patterns.ExclusivePedestrian).ToString() });
             }
 
             mainData = new
@@ -1301,6 +1305,8 @@ public partial class UISystem
                 selectedEntity = new { index = entity.Index, version = entity.Version },
                 signalConfiguration = GetTspSignalConfigurationTrace(entity),
                 trafficGroup = GetTspTrafficGroupTrace(entity),
+                selectedTopology = GetSelectedTopologyTrace(entity),
+                expectedUiState = GetExpectedUiStateTrace(entity),
                 laneSignals = GetTspLaneSignalTrace(entity, hasTrafficLights, trafficLights, hasRuntimeDebug, runtimeDebug),
                 summary,
                 trafficLights = hasTrafficLights
@@ -1397,6 +1403,157 @@ public partial class UISystem
         }
     }
 
+    private object GetSelectedTopologyTrace(Entity entity)
+    {
+        if (!m_EdgeInfoDictionary.TryGetValue(entity, out NativeArray<NodeUtils.EdgeInfo> edgeInfoArray))
+        {
+            return new
+            {
+                edgeCount = 0,
+                hasTrainTrack = false,
+                hasHighwayLane = false,
+                straightWayCount = 0,
+                hasTurningTrackLane = false,
+            };
+        }
+
+        int straightWayCount = 0;
+        bool hasTurningTrackLane = false;
+        foreach (var edgeInfo in edgeInfoArray)
+        {
+            if (edgeInfo.m_CarLaneStraightCount + edgeInfo.m_PublicCarLaneStraightCount + edgeInfo.m_TrackLaneStraightCount > 0)
+            {
+                straightWayCount++;
+            }
+            if (edgeInfo.m_TrackLaneLeftCount + edgeInfo.m_TrackLaneRightCount > 0)
+            {
+                hasTurningTrackLane = true;
+            }
+        }
+
+        return new
+        {
+            edgeCount = edgeInfoArray.Length,
+            hasTrainTrack = NodeUtils.HasTrainTrack(edgeInfoArray),
+            hasHighwayLane = HasHighwayLane(edgeInfoArray),
+            straightWayCount,
+            hasTurningTrackLane,
+        };
+    }
+
+    private object GetExpectedUiStateTrace(Entity entity)
+    {
+        CustomTrafficLights customTrafficLights = EntityManager.TryGetComponent(entity, out CustomTrafficLights value)
+            ? value
+            : new CustomTrafficLights(CustomTrafficLights.Patterns.Vanilla);
+        CustomTrafficLights.Patterns selectedPattern = customTrafficLights.GetPattern();
+        uint patternOnly = (uint)customTrafficLights.GetPatternOnly();
+        bool hasEdgeInfo = m_EdgeInfoDictionary.TryGetValue(entity, out NativeArray<NodeUtils.EdgeInfo> edgeInfoArray);
+        bool extraOptionsSupported = false;
+        bool exclusivePedestrianOptionSupported = false;
+        if (hasEdgeInfo)
+        {
+            extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
+            exclusivePedestrianOptionSupported = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(edgeInfoArray);
+        }
+        bool showOptions = patternOnly < (uint)CustomTrafficLights.Patterns.ModDefault && extraOptionsSupported;
+        bool hasExclusivePedestrian = showOptions
+            && exclusivePedestrianOptionSupported
+            && (selectedPattern & CustomTrafficLights.Patterns.ExclusivePedestrian) != 0;
+
+        return new
+        {
+            patternOnly,
+            availablePatterns = hasEdgeInfo ? GetExpectedAvailablePatternsTrace(edgeInfoArray) : new ArrayList(),
+            extraOptionsSupported,
+            exclusivePedestrianOptionSupported,
+            showOptions,
+            expectedOptions = GetExpectedOptionsTrace(selectedPattern, patternOnly, showOptions, exclusivePedestrianOptionSupported),
+            showPedestrianDuration = hasExclusivePedestrian,
+            pedestrianDurationMultiplier = customTrafficLights.m_PedestrianPhaseDurationMultiplier,
+            transitSignalPriority = GetExpectedTransitSignalPriorityUiStateTrace(entity),
+        };
+    }
+
+    private static bool HasHighwayLane(NativeArray<NodeUtils.EdgeInfo> edgeInfoArray)
+    {
+        return PredefinedPatternsProcessor.HasHighwayLane(edgeInfoArray);
+    }
+
+    private ArrayList GetExpectedAvailablePatternsTrace(NativeArray<NodeUtils.EdgeInfo> edgeInfoArray)
+    {
+        var availablePatterns = new ArrayList
+        {
+            new { name = "Vanilla", value = (uint)CustomTrafficLights.Patterns.Vanilla }
+        };
+        if (PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.SplitPhasing))
+            availablePatterns.Add(new { name = "SplitPhasing", value = (uint)CustomTrafficLights.Patterns.SplitPhasing });
+        if (PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.ProtectedCentreTurn))
+            availablePatterns.Add(new { name = m_CityConfigurationSystem.leftHandTraffic ? "ProtectedRightTurns" : "ProtectedLeftTurns", value = (uint)CustomTrafficLights.Patterns.ProtectedCentreTurn });
+        if (PredefinedPatternsProcessor.IsValidPattern(edgeInfoArray, CustomTrafficLights.Patterns.SplitPhasingProtectedLeft))
+            availablePatterns.Add(new { name = "SplitPhasingProtectedLeft", value = (uint)CustomTrafficLights.Patterns.SplitPhasingProtectedLeft });
+        availablePatterns.Add(new { name = "CustomPhases", value = (uint)CustomTrafficLights.Patterns.CustomPhase });
+        return availablePatterns;
+    }
+
+    private static ArrayList GetExpectedOptionsTrace(
+        CustomTrafficLights.Patterns selectedPattern,
+        uint patternOnly,
+        bool showOptions,
+        bool exclusivePedestrianOptionSupported)
+    {
+        return
+        [
+            new
+            {
+                label = "AllowTurningOnRed",
+                key = ((uint)CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn).ToString(),
+                isVisible = showOptions,
+                isChecked = showOptions && (selectedPattern & CustomTrafficLights.Patterns.AlwaysGreenKerbsideTurn) != 0,
+            },
+            new
+            {
+                label = "GiveWayToOncomingVehicles",
+                key = ((uint)CustomTrafficLights.Patterns.CentreTurnGiveWay).ToString(),
+                isVisible = showOptions && patternOnly == (uint)CustomTrafficLights.Patterns.Vanilla,
+                isChecked = showOptions && (selectedPattern & CustomTrafficLights.Patterns.CentreTurnGiveWay) != 0,
+            },
+            new
+            {
+                label = "ExclusivePedestrianPhase",
+                key = ((uint)CustomTrafficLights.Patterns.ExclusivePedestrian).ToString(),
+                isVisible = showOptions && exclusivePedestrianOptionSupported,
+                isChecked = showOptions
+                    && exclusivePedestrianOptionSupported
+                    && (selectedPattern & CustomTrafficLights.Patterns.ExclusivePedestrian) != 0,
+            },
+        ];
+    }
+
+    private object GetExpectedTransitSignalPriorityUiStateTrace(Entity entity)
+    {
+        TransitSignalPrioritySettings tspSettings = EntityManager.HasComponent<TransitSignalPrioritySettings>(entity)
+            ? EntityManager.GetComponentData<TransitSignalPrioritySettings>(entity)
+            : TransitSignalPrioritySettings.CreateDefault();
+        bool isTrafficGroupMember = EntityManager.HasComponent<TrafficGroupMember>(entity);
+
+        return new
+        {
+            tram = new
+            {
+                isVisible = true,
+                isEnabled = tspSettings.m_Enabled && tspSettings.m_AllowTrackRequests,
+                isEditable = !isTrafficGroupMember,
+            },
+            bus = new
+            {
+                isVisible = true,
+                isEnabled = tspSettings.m_Enabled && tspSettings.m_AllowPublicCarRequests,
+                isEditable = !isTrafficGroupMember,
+            },
+        };
+    }
+
     private object GetTspSignalConfigurationTrace(Entity entity)
     {
         CustomTrafficLights customTrafficLights = EntityManager.TryGetComponent(entity, out CustomTrafficLights value)
@@ -1418,6 +1575,7 @@ public partial class UISystem
             optionsName = options.ToString(),
             exclusivePedestrian = (pattern & CustomTrafficLights.Patterns.ExclusivePedestrian) != 0,
             smartPhaseSelection = (options & CustomTrafficLights.TrafficOptions.SmartPhaseSelection) != 0,
+            pedestrianDurationMultiplier = customTrafficLights.m_PedestrianPhaseDurationMultiplier,
             pedestrianPhaseGroupMask = customTrafficLights.m_PedestrianPhaseGroupMask,
         };
     }

--- a/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
+++ b/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
@@ -365,6 +365,33 @@ test("backend writes selected transit signal priority diagnostics to a trace fil
   assert.match(uiBindings, /FileMode\.Append/);
 });
 
+test("backend trace includes selected topology and expected UI option state", async () => {
+  const uiBindings = await repoSource("Systems/UI/UISystem.UIBIndings.cs");
+  const traceStart = uiBindings.indexOf("private void WriteTspDiagnosticsTraceEvent");
+  const traceEnd = uiBindings.indexOf("private object GetTspSignalConfigurationTrace", traceStart);
+  const traceSource = uiBindings.slice(traceStart, traceEnd);
+
+  assert.notEqual(traceStart, -1);
+  assert.notEqual(traceEnd, -1);
+  assert.match(traceSource, /selectedTopology\s*=\s*GetSelectedTopologyTrace\(entity\)/);
+  assert.match(traceSource, /expectedUiState\s*=\s*GetExpectedUiStateTrace\(entity\)/);
+  assert.match(uiBindings, /edgeCount\s*=\s*edgeInfoArray\.Length/);
+  assert.match(uiBindings, /hasHighwayLane\s*=\s*HasHighwayLane\(edgeInfoArray\)/);
+  assert.match(uiBindings, /hasTrainTrack\s*=\s*NodeUtils\.HasTrainTrack\(edgeInfoArray\)/);
+  assert.match(uiBindings, /extraOptionsSupported\s*=\s*PredefinedPatternsProcessor\.AreExtraOptionsSupported\(edgeInfoArray\)/);
+  assert.match(uiBindings, /exclusivePedestrianOptionSupported\s*=\s*PredefinedPatternsProcessor\.IsExclusivePedestrianOptionSupported\(edgeInfoArray\)/);
+  assert.match(uiBindings, /options\.Add\(new\s*\{\s*label\s*=\s*"ExclusivePedestrianPhase"[\s\S]*?\}\);/);
+  assert.match(uiBindings, /if\s*\(\s*exclusivePedestrianOptionSupported\s*\)\s*[\r\n\s]*options\.Add\(new\s*\{\s*label\s*=\s*"ExclusivePedestrianPhase"/);
+  assert.match(uiBindings, /showOptions\s*=\s*patternOnly\s*<\s*\(uint\)CustomTrafficLights\.Patterns\.ModDefault\s*&&\s*extraOptionsSupported/);
+  assert.match(uiBindings, /expectedOptions/);
+  assert.match(uiBindings, /AllowTurningOnRed/);
+  assert.match(uiBindings, /GiveWayToOncomingVehicles/);
+  assert.match(uiBindings, /ExclusivePedestrianPhase/);
+  assert.match(uiBindings, /pedestrianDurationMultiplier\s*=\s*customTrafficLights\.m_PedestrianPhaseDurationMultiplier/);
+  assert.match(uiBindings, /showPedestrianDuration\s*=\s*hasExclusivePedestrian/);
+  assert.match(uiBindings, /transitSignalPriority\s*=\s*GetExpectedTransitSignalPriorityUiStateTrace/);
+});
+
 test("runtime suspends transit signal priority for all traffic group members", async () => {
   const runtime = await repoSource("Systems/TrafficLightSystems/Simulation/TransitSignalPriorityRuntime.cs");
   const patchedSystem = await repoSource("Systems/TrafficLightSystems/Simulation/PatchedTrafficLightSystem.cs");

--- a/TrafficLightsEnhancement/Utils/NodeUtils.EdgeInfo.cs
+++ b/TrafficLightsEnhancement/Utils/NodeUtils.EdgeInfo.cs
@@ -33,6 +33,8 @@ public partial struct NodeUtils
 
         public int m_PublicCarLaneUTurnCount;
 
+        public int m_HighwayLaneCount;
+
         public int m_TrackLaneLeftCount;
 
         public int m_TrackLaneStraightCount;
@@ -85,6 +87,8 @@ public partial struct NodeUtils
             writer.Write(m_PublicCarLaneRightCount);
             writer.PropertyName("m_PublicCarLaneUTurnCount");
             writer.Write(m_PublicCarLaneUTurnCount);
+            writer.PropertyName("m_HighwayLaneCount");
+            writer.Write(m_HighwayLaneCount);
             writer.PropertyName("m_TrackLaneLeftCount");
             writer.Write(m_TrackLaneLeftCount);
             writer.PropertyName("m_TrackLaneStraightCount");

--- a/TrafficLightsEnhancement/Utils/NodeUtils.cs
+++ b/TrafficLightsEnhancement/Utils/NodeUtils.cs
@@ -117,6 +117,8 @@ public partial struct NodeUtils
                         {
                             carLaneLookup.TryGetComponent(laneConnection.m_SourceSubLane, out var edgeCarLane);
                             bool isPublicOnly = (edgeCarLane.m_Flags & CarLaneFlags.PublicOnly) != 0;
+                            bool isHighway = (edgeCarLane.m_Flags & CarLaneFlags.Highway) != 0 ||
+                                (nodeCarLane.m_Flags & CarLaneFlags.Highway) != 0;
                             bool isUTurn = (nodeCarLane.m_Flags & (CarLaneFlags.UTurnLeft | CarLaneFlags.UTurnRight)) != 0;
                             if (!isUTurn && (nodeCarLane.m_Flags & (CarLaneFlags.TurnLeft | CarLaneFlags.GentleTurnLeft)) != 0)
                             {
@@ -142,6 +144,7 @@ public partial struct NodeUtils
                                 edgeInfo.m_CarLaneUTurnCount += System.Convert.ToInt32(!isPublicOnly);
                                 sourceSubLaneInfo.m_CarLaneUTurnCount++;
                             }
+                            edgeInfo.m_HighwayLaneCount += System.Convert.ToInt32(isHighway);
                             subLaneMap[laneConnection.m_SourceSubLane] = sourceSubLaneInfo;
                         }
                     }


### PR DESCRIPTION
*Written by Codex.*

## Summary

- Gate extra signal options through a shared topology check instead of the panel's old train-track-only check.
- Require `Split Phasing + Protected Left` to pass both split-phasing and protected-turn topology checks.
- Clear unsupported extra option flags during traffic-light initialization so runtime state matches the UI gate.
- Add ECS regression coverage for the UI and initialization gates.

## Root Cause

The selected-intersection panel had drifted from the topology rules used by predefined signal modes. Extra options were shown whenever the selected pattern was predefined and the junction had no train track, so complex road topologies could still offer option checkboxes. The combined split-phasing/protected-left mode also used only the loose split-phasing edge-count check, so it could appear even when standalone protected turns were invalid.

## Validation

- `dotnet test TrafficLightsEnhancement.Ecs.Tests\TrafficLightsEnhancement.Ecs.Tests.csproj --no-restore` passed: 49 passed, 0 failed.
- `dotnet build --configuration Release` succeeded and installed a local test build into the Cities: Skylines II mods folder.
- Local playtest confirmed the complex junction no longer shows protected-turn choices, including `Split Phasing + Protected Left`.

Fixes #102