### PR TITLE
[codex] Fix stale main-panel option state when selecting different junctions

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/UISystemSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/UISystemSourceTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace TrafficLightsEnhancement.Ecs.Tests;
+
+public sealed class UISystemSourceTests
+{
+    [Fact]
+    public void ChangeSelectedEntity_assigns_entity_and_custom_lights_before_updating_bindings()
+    {
+        string source = File.ReadAllText(GetRepoPath("TrafficLightsEnhancement", "Systems", "UI", "UISystem.cs"));
+        string changeSelectedSource = ExtractMethod(source, "public void ChangeSelectedEntity");
+
+        int selectedEntityAssignIndex = changeSelectedSource.IndexOf("m_SelectedEntity = entity;", StringComparison.Ordinal);
+        int customTrafficLightsAssignIndex = changeSelectedSource.IndexOf("m_CustomTrafficLights =", StringComparison.Ordinal);
+        int updateEdgeInfoIndex = changeSelectedSource.IndexOf("UpdateEdgeInfo(entity);", StringComparison.Ordinal);
+        int setMainPanelIndex = changeSelectedSource.IndexOf("SetMainPanelState(MainPanelState.Main);", StringComparison.Ordinal);
+
+        Assert.True(selectedEntityAssignIndex >= 0, "m_SelectedEntity assignment was not found.");
+        Assert.True(customTrafficLightsAssignIndex >= 0, "m_CustomTrafficLights assignment was not found.");
+        Assert.True(updateEdgeInfoIndex >= 0, "UpdateEdgeInfo(entity) was not found.");
+        Assert.True(setMainPanelIndex >= 0, "SetMainPanelState(MainPanelState.Main) was not found.");
+
+        Assert.True(selectedEntityAssignIndex < updateEdgeInfoIndex, "m_SelectedEntity must be assigned before UpdateEdgeInfo(entity).");
+        Assert.True(customTrafficLightsAssignIndex < updateEdgeInfoIndex, "m_CustomTrafficLights must be assigned before UpdateEdgeInfo(entity).");
+        Assert.True(updateEdgeInfoIndex < setMainPanelIndex, "UpdateEdgeInfo(entity) must occur before SetMainPanelState(MainPanelState.Main).");
+    }
+
+    private static string GetRepoPath(params string[] segments)
+    {
+        string path = AppContext.BaseDirectory;
+        for (int i = 0; i < 4; i++)
+        {
+            path = Path.GetDirectoryName(path) ?? throw new DirectoryNotFoundException(path);
+        }
+
+        path = Path.Combine(path, Path.Combine(segments));
+        Assert.True(File.Exists(path), $"Could not find expected repo file at {path}");
+        return path;
+    }
+
+    private static string ExtractMethod(string source, string signature)
+    {
+        int start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Could not find method signature: {signature}");
+
+        int braceStart = source.IndexOf('{', start);
+        Assert.True(braceStart >= 0, $"Could not find method body: {signature}");
+
+        int depth = 0;
+        for (int i = braceStart; i < source.Length; i++)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return source.Substring(start, i - start + 1);
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Could not parse method body: {signature}");
+    }
+}

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.cs
@@ -374,7 +374,7 @@ public partial class UISystem: ExtendedUISystemBase
                 
                 m_ShowNotificationUnsaved = false;
                 ClearEdgeInfo();
-                UpdateEdgeInfo(entity);
+
                 m_SelectedEntity = entity;
                 
                 if (EntityManager.HasComponent<CustomTrafficLights>(entity))
@@ -385,6 +385,8 @@ public partial class UISystem: ExtendedUISystemBase
                 {
                     m_CustomTrafficLights = new CustomTrafficLights(CustomTrafficLights.Patterns.Vanilla);
                 }
+
+                UpdateEdgeInfo(entity);
                 
                 SetMainPanelState(MainPanelState.TrafficGroups);
             }
@@ -415,8 +417,7 @@ public partial class UISystem: ExtendedUISystemBase
 
             if (!entity.Equals(Entity.Null))
             {
-                UpdateEdgeInfo(entity);
-                SetMainPanelState(MainPanelState.Main);
+                m_SelectedEntity = entity;
 
                 if (EntityManager.HasComponent<CustomTrafficLights>(entity))
                 {
@@ -426,13 +427,18 @@ public partial class UISystem: ExtendedUISystemBase
                 {
                     m_CustomTrafficLights = new CustomTrafficLights(CustomTrafficLights.Patterns.Vanilla);
                 }
-            }
-            else if (m_MainPanelState != MainPanelState.Hidden)
-            {
-                SetMainPanelState(MainPanelState.Empty);
-            }
 
-            m_SelectedEntity = entity;
+                UpdateEdgeInfo(entity);
+                SetMainPanelState(MainPanelState.Main);
+            }
+            else
+            {
+                if (m_MainPanelState != MainPanelState.Hidden)
+                {
+                    SetMainPanelState(MainPanelState.Empty);
+                }
+                m_SelectedEntity = entity;
+            }
         }
     }
 }


### PR DESCRIPTION
*Written by Antigravity.*

## Summary

This PR resolves #112. It fixes a bug where the visible main panel options render from the stale cached state of the previously selected junction, rather than the newly selected one.

- **Reorder assignment/loading state**: In `UISystem.ChangeSelectedEntity`, reordered `m_SelectedEntity` assignment and `m_CustomTrafficLights` loading so they are fully populated *before* calling `UpdateEdgeInfo(entity)` and `SetMainPanelState(MainPanelState.Main)`. This guarantees that UI bindings evaluating during those calls do not retrieve stale cached data.
- **Source-level regression test**: Added a static source analysis test in `UISystemSourceTests.cs` to verify that `m_SelectedEntity` and `m_CustomTrafficLights` are assigned before `UpdateEdgeInfo` and `SetMainPanelState` in `ChangeSelectedEntity`.

## Verification

- Sequential C# tests: `dotnet test Cities2-TrafficLightsEnhancement.sln -m:1` (63 passed, including the new regression test)
- UI tests: `npm.cmd test --prefix TrafficLightsEnhancement/UI` (48 passed)
