### PR TITLE
[codex] Hide tram TSP control if intersection has no tram tracks

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/UISystemSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/UISystemSourceTests.cs
@@ -27,6 +27,17 @@ public sealed class UISystemSourceTests
         Assert.True(updateEdgeInfoIndex < setMainPanelIndex, "UpdateEdgeInfo(entity) must occur before SetMainPanelState(MainPanelState.Main).");
     }
 
+    [Fact]
+    public void GetSelectedJunctionDiagnosticsSnapshot_gates_tram_tsp_visibility_by_tram_track_presence()
+    {
+        string source = File.ReadAllText(GetRepoPath("TrafficLightsEnhancement", "Systems", "UI", "UISystem.UIBIndings.cs"));
+        string getSnapshotSource = ExtractMethod(source, "private SelectedJunctionDiagnosticsSnapshot GetSelectedJunctionDiagnosticsSnapshot");
+
+        Assert.Contains("TramTransitPriority = new SelectedJunctionTspControlSnapshot(", getSnapshotSource);
+        Assert.Contains("isVisible: HasTramTrack(edgeInfoArray),", getSnapshotSource);
+        Assert.Contains("private bool HasTramTrack(NativeArray<NodeUtils.EdgeInfo> edgeInfoArray)", source);
+    }
+
     private static string GetRepoPath(params string[] segments)
     {
         string path = AppContext.BaseDirectory;

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
@@ -1628,7 +1628,7 @@ public partial class UISystem
                 false,
                 hasExclusivePedestrian ? "Visible" : "Exclusive pedestrian phase disabled"),
             TramTransitPriority = new SelectedJunctionTspControlSnapshot(
-                isVisible: true,
+                isVisible: HasTramTrack(edgeInfoArray),
                 isEditable: isEditable,
                 isChecked: tspSettings.m_Enabled && tspSettings.m_AllowTrackRequests,
                 statusLabel: tramStatusLabel,
@@ -1640,6 +1640,39 @@ public partial class UISystem
                 statusLabel: busStatusLabel,
                 reason: isTrafficGroupMember ? "Traffic group member" : "Editable"),
         };
+    }
+
+    private bool HasTramTrack(NativeArray<NodeUtils.EdgeInfo> edgeInfoArray)
+    {
+        var trackLaneLookup = GetComponentLookup<TrackLane>(true);
+        var prefabRefLookup = GetComponentLookup<Game.Prefabs.PrefabRef>(true);
+        var trackLaneDataLookup = GetComponentLookup<Game.Prefabs.TrackLaneData>(true);
+
+        foreach (var edgeInfo in edgeInfoArray)
+        {
+            if (edgeInfo.m_SubLaneInfoList.IsCreated)
+            {
+                foreach (var subLaneInfo in edgeInfo.m_SubLaneInfoList)
+                {
+                    Entity laneEntity = subLaneInfo.m_SubLane;
+                    if (laneEntity != Entity.Null && trackLaneLookup.HasComponent(laneEntity))
+                    {
+                        if (prefabRefLookup.TryGetComponent(laneEntity, out var prefabRef))
+                        {
+                            if (trackLaneDataLookup.TryGetComponent(prefabRef.m_Prefab, out var trackLaneData))
+                            {
+                                if ((trackLaneData.m_TrackTypes & Game.Net.TrackTypes.Tram) != 0)
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private List<SelectedJunctionPatternSnapshot> GetAvailablePatternSnapshots(


### PR DESCRIPTION
*Written by Antigravity.*

## Summary

This PR resolves #105. It gates the visibility of the `Enable for trams` Transit Signal Priority option by the presence of tram tracks connected to the selected intersection.

- **Check tram track presence**: Added `HasTramTrack(NativeArray<NodeUtils.EdgeInfo> edgeInfoArray)` inside `UISystem.UIBIndings.cs` that iterates over connected edge sub-lanes and queries their prefab's `TrackLaneData` to check if `TrackTypes.Tram` is set.
- **Gate UI option visibility**: Set the `isVisible` flag for `TramTransitPriority` control snapshot to evaluate using `HasTramTrack(edgeInfoArray)`.
- **Source-level regression test**: Added a static source analysis test in `UISystemSourceTests.cs` to ensure that `TramTransitPriority` is created with its visibility gated by `HasTramTrack(edgeInfoArray)`.

## Verification

- Sequential C# tests: `dotnet test Cities2-TrafficLightsEnhancement.sln -m:1` (64 passed, including the new regression test)
- UI tests: `npm.cmd test --prefix TrafficLightsEnhancement/UI` (48 passed)
