### PR TITLE
[codex] Refactor GetEdgeInfoList to fix native memory leak

### DIFF
--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
@@ -244,7 +244,7 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                 }
                 else
                 {
-                  var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]).AsArray();
+                  var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]);
                   bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
                   bool exclusivePedestrianOptionSupported = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(edgeInfoArray);
                   var pattern = customTrafficLights.GetPattern();
@@ -261,6 +261,7 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                   {
                       customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExclusivePedestrianOption(pattern));
                   }
+                  NodeUtils.Dispose(edgeInfoArray);
                     if (customTrafficLights.GetPatternOnly() == CustomTrafficLights.Patterns.SplitPhasing)
                     {
                         PredefinedPatternsProcessor.SetupSplitPhasing(ref this, connectedEdgeAccessor[i], subLanes, out groupCount, ref trafficLights);

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.cs
@@ -247,7 +247,7 @@ public partial class UISystem: ExtendedUISystemBase
         
         ClearEdgeInfo();
         
-        m_EdgeInfoDictionary[node] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, node, this).AsArray();
+        m_EdgeInfoDictionary[node] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, node, this);
         
         if (EntityManager.HasComponent<TrafficGroupMember>(node))
         {
@@ -267,7 +267,7 @@ public partial class UISystem: ExtendedUISystemBase
                         
                         if (hasPhases)
                         {
-                            m_EdgeInfoDictionary[memberEntity] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, memberEntity, this).AsArray();
+                            m_EdgeInfoDictionary[memberEntity] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, memberEntity, this);
                         }
                     }
                 }

--- a/TrafficLightsEnhancement/Utils/NodeUtils.cs
+++ b/TrafficLightsEnhancement/Utils/NodeUtils.cs
@@ -32,7 +32,7 @@ public partial struct NodeUtils
         }
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList
+    public static NativeArray<EdgeInfo> GetEdgeInfoList
     (
         Allocator allocator,
         Entity nodeEntity,
@@ -56,8 +56,8 @@ public partial struct NodeUtils
         ComponentLookup<CarLaneData> carLaneDataLookup
     )
     {
-        NativeList<EdgeInfo> edgeInfoList = new(4, allocator);
-        NativeHashMap<Entity, LaneConnection> laneConnectionMap = GetLaneConnectionMap(Allocator.Temp, nodeSubLaneBuffer, connectedEdgeBuffer, subLaneLookup, laneLookup);
+        using NativeList<EdgeInfo> edgeInfoList = new(4, Allocator.Temp);
+        using var laneConnectionMap = GetLaneConnectionMap(Allocator.Temp, nodeSubLaneBuffer, connectedEdgeBuffer, subLaneLookup, laneLookup);
 
         foreach (ConnectedEdge connectedEdge in connectedEdgeBuffer)
         {
@@ -69,8 +69,8 @@ public partial struct NodeUtils
             edgeInfo.m_Position = edgePosition;
             CustomPhaseUtils.TryGet(edgeGroupMaskBuffer, edgeEntity, edgePosition, out edgeInfo.m_EdgeGroupMask);
 
-            NativeHashMap<Entity, SubLaneInfo> subLaneMap = new(16, Allocator.Temp);
-            NativeList<SubLaneInfo> subLaneInfoList = new(16, allocator);
+            var subLaneMap = new NativeHashMap<Entity, SubLaneInfo>(16, Allocator.Temp);
+            var subLaneInfoList = new NativeList<SubLaneInfo>(16, Allocator.Temp);
 
             foreach (SubLane nodeSubLane in nodeSubLaneBuffer)
             {
@@ -197,14 +197,20 @@ public partial struct NodeUtils
                 CustomPhaseUtils.TryGet(subLaneGroupMaskBuffer, subLaneInfo.m_SubLane, subLaneInfo.m_Position, out subLaneInfo.m_SubLaneGroupMask);
                 subLaneInfoList.Add(subLaneInfo);
             }
-            edgeInfo.m_SubLaneInfoList = subLaneInfoList.AsArray();
+            edgeInfo.m_SubLaneInfoList = new NativeArray<SubLaneInfo>(subLaneInfoList.Length, allocator);
+            edgeInfo.m_SubLaneInfoList.CopyFrom(subLaneInfoList.AsArray());
             edgeInfoList.Add(edgeInfo);
+
+            subLaneMap.Dispose();
+            subLaneInfoList.Dispose();
         }
 
-        return edgeInfoList;
+        var edgeInfoArray = new NativeArray<EdgeInfo>(edgeInfoList.Length, allocator);
+        edgeInfoArray.CopyFrom(edgeInfoList.AsArray());
+        return edgeInfoArray;
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, Systems.UI.UISystem uISystem)
+    public static NativeArray<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, Systems.UI.UISystem uISystem)
     {
         uISystem.m_TypeHandle.Update(uISystem);
         uISystem.m_TypeHandle.m_SubLane.TryGetBuffer(nodeEntity, out var nodeSubLaneBuffer);
@@ -236,7 +242,7 @@ public partial struct NodeUtils
         );
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, ref InitializeTrafficLightsJob job, DynamicBuffer<SubLane> nodeSubLaneBuffer, DynamicBuffer<ConnectedEdge> connectedEdgeBuffer, DynamicBuffer<EdgeGroupMask> edgeGroupMaskBuffer, DynamicBuffer<SubLaneGroupMask> subLaneGroupMaskBuffer)
+    public static NativeArray<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, ref InitializeTrafficLightsJob job, DynamicBuffer<SubLane> nodeSubLaneBuffer, DynamicBuffer<ConnectedEdge> connectedEdgeBuffer, DynamicBuffer<EdgeGroupMask> edgeGroupMaskBuffer, DynamicBuffer<SubLaneGroupMask> subLaneGroupMaskBuffer)
     {
         return GetEdgeInfoList
         (


### PR DESCRIPTION
*Written by Antigravity.*

## Summary
This pull request addresses **Issue #108** by refactoring the `GetEdgeInfoList` overloads and callers to correctly resolve a native memory leak in the traffic light initialization path.

### Root Cause
`GetEdgeInfoList` previously returned a `NativeList<EdgeInfo>`, and callers (such as `PatchedTrafficLightInitializationSystem` and `UISystem`) called `.AsArray()` on it. This caused:
1. The parent `NativeList<EdgeInfo>` structure to be discarded and leaked.
2. The nested lists `m_SubLaneInfoList` inside `EdgeInfo` (allocated with the caller's allocator) to be leaked.
3. Attempting to call `.Dispose()` on the aliased arrays threw exceptions under Unity Collections safety checks or was a silent no-op in release builds.

### Changes
1. **Refactored `GetEdgeInfoList`**:
   - Signature updated to return a direct allocation `NativeArray<EdgeInfo>` instead of `NativeList`.
   - Used `Allocator.Temp` for internal collection lists and disposed them at the end of execution.
   - Performed a deep copy of elements to direct `NativeArray` allocations to avoid aliasing disposal issues:
     ```csharp
     edgeInfo.m_SubLaneInfoList = new NativeArray<SubLaneInfo>(subLaneInfoList.Length, allocator);
     edgeInfo.m_SubLaneInfoList.CopyFrom(subLaneInfoList.AsArray());
     ```
2. **Caller Updates**:
   - In `PatchedTrafficLightInitializationSystem`, removed `.AsArray()` and added `NodeUtils.Dispose(edgeInfoArray)` immediately after pattern validation.
   - In `UISystem`, removed `.AsArray()` from the Persistent dictionary allocations.
3. **Issue #109 Alignment**: Verified that Issue #109 is already fixed and covered by existing tests in `main`.

### Verification
- Both full solution compilation and all C# unit, serialization, and ECS tests passed successfully.
- Code reviewed and approved by subagents.
