### PR TITLE
[codex] Expose separate train and track-lane counts in selected-junction diagnostics

### DIFF
--- a/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
@@ -56,6 +56,11 @@ public partial class UISystem
         public bool HasTrackTurnLanes;
         public bool IsQualifyingFourWay;
         public bool IsComplexJunction;
+        public int TrainTrackCount;
+        public int TrackLaneLeftCount;
+        public int TrackLaneStraightCount;
+        public int TrackLaneRightCount;
+        public int TotalTrackLaneCount;
         public ArrayList EdgeSummaries = [];
         public bool SplitPhasingSupported;
         public bool ProtectedCentreTurnSupported;
@@ -94,6 +99,11 @@ public partial class UISystem
                 hasTrackTurnLanes = HasTrackTurnLanes,
                 isQualifyingFourWay = IsQualifyingFourWay,
                 isComplexJunction = IsComplexJunction,
+                trainTrackCount = TrainTrackCount,
+                trackLaneLeftCount = TrackLaneLeftCount,
+                trackLaneStraightCount = TrackLaneStraightCount,
+                trackLaneRightCount = TrackLaneRightCount,
+                totalTrackLaneCount = TotalTrackLaneCount,
                 edges = EdgeSummaries,
             },
             patterns = new
@@ -1592,6 +1602,19 @@ public partial class UISystem
         string tramStatusLabel = isTrafficGroupMember ? "TramTransitPriorityGroupedUnavailable" : null;
         string busStatusLabel = isTrafficGroupMember ? "BusTransitPriorityGroupedUnavailable" : null;
 
+        int trainTrackCount = 0;
+        int trackLaneLeftCount = 0;
+        int trackLaneStraightCount = 0;
+        int trackLaneRightCount = 0;
+        foreach (var edge in edgeInfoArray)
+        {
+            trainTrackCount += edge.m_TrainTrackCount;
+            trackLaneLeftCount += edge.m_TrackLaneLeftCount;
+            trackLaneStraightCount += edge.m_TrackLaneStraightCount;
+            trackLaneRightCount += edge.m_TrackLaneRightCount;
+        }
+        int totalTrackLaneCount = trackLaneLeftCount + trackLaneStraightCount + trackLaneRightCount;
+
         return new SelectedJunctionDiagnosticsSnapshot
         {
             ConnectedEdgeCount = edgeInfoArray.Length,
@@ -1599,6 +1622,11 @@ public partial class UISystem
             HasTrackTurnLanes = includeDiagnosticsDetails && HasTrackTurnLanes(edgeInfoArray),
             IsQualifyingFourWay = includeDiagnosticsDetails && IsQualifyingFourWay(edgeInfoArray),
             IsComplexJunction = edgeInfoArray.Length > 7,
+            TrainTrackCount = trainTrackCount,
+            TrackLaneLeftCount = trackLaneLeftCount,
+            TrackLaneStraightCount = trackLaneStraightCount,
+            TrackLaneRightCount = trackLaneRightCount,
+            TotalTrackLaneCount = totalTrackLaneCount,
             EdgeSummaries = includeDiagnosticsDetails ? GetSelectedJunctionEdgeSummaries(edgeInfoArray) : [],
             SplitPhasingSupported = splitPhasingSupported,
             ProtectedCentreTurnSupported = protectedCentreTurnSupported,
@@ -1991,12 +2019,17 @@ public partial class UISystem
     {
         return string.Format(
             CultureInfo.InvariantCulture,
-            "edges={0}, train={1}, track turns={2}, four-way={3}, complex={4}",
+            "edges={0}, train={1}, track turns={2}, four-way={3}, complex={4}, trainTrackCount={5}, trackLaneStraightCount={6}, trackLaneLeftCount={7}, trackLaneRightCount={8}, totalTrackLaneCount={9}",
             selectedJunction.ConnectedEdgeCount,
             FormatYesNo(selectedJunction.HasTrainTrack),
             FormatYesNo(selectedJunction.HasTrackTurnLanes),
             FormatYesNo(selectedJunction.IsQualifyingFourWay),
-            FormatYesNo(selectedJunction.IsComplexJunction));
+            FormatYesNo(selectedJunction.IsComplexJunction),
+            selectedJunction.TrainTrackCount,
+            selectedJunction.TrackLaneStraightCount,
+            selectedJunction.TrackLaneLeftCount,
+            selectedJunction.TrackLaneRightCount,
+            selectedJunction.TotalTrackLaneCount);
     }
 
     private static string FormatAvailablePatterns(IEnumerable<SelectedJunctionPatternSnapshot> availablePatterns)

--- a/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
+++ b/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
@@ -415,7 +415,11 @@ test("backend trace includes selected junction topology and expected UI state", 
   assert.match(uiBindings, /hasTrainTrack\s*=\s*HasTrainTrack/);
   assert.match(uiBindings, /hasTrackTurnLanes\s*=\s*HasTrackTurnLanes/);
   assert.match(uiBindings, /isQualifyingFourWay\s*=\s*IsQualifyingFourWay/);
-  assert.match(uiBindings, /isComplexJunction\s*=\s*IsComplexJunction/);
+  assert.match(uiBindings, /trainTrackCount\s*=\s*TrainTrackCount/);
+  assert.match(uiBindings, /trackLaneLeftCount\s*=\s*TrackLaneLeftCount/);
+  assert.match(uiBindings, /trackLaneStraightCount\s*=\s*TrackLaneStraightCount/);
+  assert.match(uiBindings, /trackLaneRightCount\s*=\s*TrackLaneRightCount/);
+  assert.match(uiBindings, /totalTrackLaneCount\s*=\s*TotalTrackLaneCount/);
   assert.match(uiBindings, /splitPhasingSupported\s*=\s*SplitPhasingSupported/);
   assert.match(uiBindings, /protectedCentreTurnSupported\s*=\s*ProtectedCentreTurnSupported/);
   assert.match(uiBindings, /splitPhasingProtectedLeftSupported\s*=\s*SplitPhasingProtectedLeftSupported/);
@@ -426,6 +430,21 @@ test("backend trace includes selected junction topology and expected UI state", 
   assert.match(uiBindings, /pedestrianDurationAdjustment\s*=\s*PedestrianDurationAdjustment\.ToTraceObject\(\)/);
   assert.match(uiBindings, /tram\s*=\s*TramTransitPriority\.ToTraceObject\(\)/);
   assert.match(uiBindings, /bus\s*=\s*BusTransitPriority\.ToTraceObject\(\)/);
+});
+
+test("backend diagnostics snapshot exposes expected fields", async () => {
+  const uiBindings = await repoSource("Systems/UI/UISystem.UIBIndings.cs");
+  const snapshotStart = uiBindings.indexOf("private sealed class SelectedJunctionDiagnosticsSnapshot");
+  const snapshotEnd = uiBindings.indexOf("public ArrayList AvailablePatterns", snapshotStart);
+  const snapshotSource = uiBindings.slice(snapshotStart, snapshotEnd);
+
+  assert.notEqual(snapshotStart, -1);
+  assert.notEqual(snapshotEnd, -1);
+  assert.match(snapshotSource, /public\s+int\s+TrainTrackCount;/);
+  assert.match(snapshotSource, /public\s+int\s+TrackLaneLeftCount;/);
+  assert.match(snapshotSource, /public\s+int\s+TrackLaneStraightCount;/);
+  assert.match(snapshotSource, /public\s+int\s+TrackLaneRightCount;/);
+  assert.match(snapshotSource, /public\s+int\s+TotalTrackLaneCount;/);
 });
 
 test("backend distinguishes selected junction option support from current visibility", async () => {

--- a/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
+++ b/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
@@ -415,6 +415,7 @@ test("backend trace includes selected junction topology and expected UI state", 
   assert.match(uiBindings, /hasTrainTrack\s*=\s*HasTrainTrack/);
   assert.match(uiBindings, /hasTrackTurnLanes\s*=\s*HasTrackTurnLanes/);
   assert.match(uiBindings, /isQualifyingFourWay\s*=\s*IsQualifyingFourWay/);
+  assert.match(uiBindings, /isComplexJunction\s*=\s*IsComplexJunction/);
   assert.match(uiBindings, /trainTrackCount\s*=\s*TrainTrackCount/);
   assert.match(uiBindings, /trackLaneLeftCount\s*=\s*TrackLaneLeftCount/);
   assert.match(uiBindings, /trackLaneStraightCount\s*=\s*TrackLaneStraightCount/);


### PR DESCRIPTION
*Written by Antigravity.*

## Summary
This pull request addresses **Issue #113** by exposing separate aggregate train and track-lane counts in the selected-junction diagnostics panel and trace files.

- **Snapshot Extensions**: Added `TrainTrackCount`, `TrackLaneLeftCount`, `TrackLaneStraightCount`, `TrackLaneRightCount`, and `TotalTrackLaneCount` to `SelectedJunctionDiagnosticsSnapshot`.
- **Calculations**: Summed counts from the connected `edgeInfoArray` in `GetSelectedJunctionDiagnosticsSnapshot()` to compute aggregate values.
- **Trace Output**: Updated `ToTraceObject()` to serialize the counts under the `topology` property of trace snapshot JSON.
- **UI Diagnostics Format**: Updated `FormatSelectedJunctionTopology()` to format these new counts in the diagnostics panel topology string.
- **Test-Driven Development**: Added failing UI test coverage first in `transit-signal-priority-panel.test.mjs`, verified the failures, and subsequently implemented the changes to pass the tests.

## Test Plan
- Run C# backend tests: `dotnet test Cities2-TrafficLightsEnhancement.sln -m:1`
- Run UI frontend tests: `npm.cmd test --prefix TrafficLightsEnhancement/UI`
