### PR TITLE
chore: mirror .agents/skills into .claude/skills for native skill discovery

### DIFF
--- a/.claude/skills/tle-code-documentation
+++ b/.claude/skills/tle-code-documentation
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-code-documentation

--- a/.claude/skills/tle-code-review
+++ b/.claude/skills/tle-code-review
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-code-review

--- a/.claude/skills/tle-codebase
+++ b/.claude/skills/tle-codebase
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-codebase

--- a/.claude/skills/tle-csharp-ecs
+++ b/.claude/skills/tle-csharp-ecs
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-csharp-ecs

--- a/.claude/skills/tle-diagnostic-review
+++ b/.claude/skills/tle-diagnostic-review
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-diagnostic-review

--- a/.claude/skills/tle-testing-release
+++ b/.claude/skills/tle-testing-release
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-testing-release

--- a/.claude/skills/tle-ui-localization
+++ b/.claude/skills/tle-ui-localization
@@ -1,0 +1,1 @@
+../../.agents/skills/tle-ui-localization


### PR DESCRIPTION
*Written by Claude.*

## Summary
Claude Code auto-discovers project skills from `.claude/skills/`, but the repo's canonical skills live in `.agents/skills/` (portable, cross-agent). As a result the `tle-*` skills weren't registering as native, `/`-invocable skills — agents had to read them manually via the AGENTS.md pointer.

This adds relative symlinks so they're discovered natively, with **no content duplication** — `.agents/skills/` stays the single source of truth:

```
.claude/skills/<name> -> ../../.agents/skills/<name>   (7 skills, mode 120000)
```

## Notes
- Real symlinks require `core.symlinks=true` and OS symlink support. macOS/Linux clones get them automatically; **Windows clones need Developer Mode** (or they materialize as text stand-ins). This matches the repo's existing multi-platform shim approach.
- `.agents/skills/` remains canonical per AGENTS.md; this is a thin discovery shim, not a duplicate.

## Verification
- All 7 symlinks resolve to their target `SKILL.md` (7/7).
- Committed as git mode `120000` (verified via `git ls-tree`).