### PR TITLE
Drop internal rationale from GUIDE diagnostics file-name note

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -110,7 +110,7 @@ On Windows, the active trace file is written to:
 C:\Users\<your user name>\AppData\LocalLow\Colossal Order\Cities Skylines II\C2VM.TrafficLightsEnhancement.TspDiagnostics.jsonl
 ```
 
-The file name still uses the original `TspDiagnostics` name for compatibility with existing troubleshooting workflows. When the file reaches 5 MB, the mod rotates it in the same folder with a timestamped name such as `C2VM.TrafficLightsEnhancement.TspDiagnostics.20260527091530.jsonl`. It keeps the active file plus the newest three rotated files.
+When the file reaches 5 MB, the mod rotates it in the same folder with a timestamped name such as `C2VM.TrafficLightsEnhancement.TspDiagnostics.20260527091530.jsonl`. It keeps the active file plus the newest three rotated files.
 
 ### Common Diagnostics Fields
 


### PR DESCRIPTION
*Written by Claude.*

## Summary

Removes one navel-gazing sentence from `GUIDE.md`: "The file name still uses the original `TspDiagnostics` name for compatibility with existing troubleshooting workflows." It explains an internal-history detail that means nothing to a player reading the guide — and the filename is already shown in the code block directly above it. The actionable rotation details are kept.

## Verification

Docs-only change. No code or tests affected (the JSONL trace filename itself is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)