### PR TITLE
[codex] Clean up diagnostics trace selection and edge info ownership

### DIFF
--- a/TrafficLightsEnhancement.Ecs.Tests/CopyPhasesToAllMembersSourceTests.cs
+++ b/TrafficLightsEnhancement.Ecs.Tests/CopyPhasesToAllMembersSourceTests.cs
@@ -38,7 +38,7 @@ public sealed class CopyPhasesToAllMembersSourceTests
         string batch = ExtractMethod(source, "public void CopyPhasesToAllMembers");
 
         Assert.Contains("TryCopyPhasesToJunction(", batch);
-        Assert.Equal(1, Regex.Matches(batch, "ShowMessageDialog").Count);
+        Assert.Single(Regex.Matches(batch, "ShowMessageDialog"));
         // Members come from a Temp NativeList that must be released.
         Assert.Contains(".Dispose()", batch);
     }

--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs
@@ -244,7 +244,7 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                 }
                 else
                 {
-                  var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]).AsArray();
+                  var edgeInfoArray = NodeUtils.GetEdgeInfoList(Allocator.Temp, entityArray[i], ref this, subLanes, connectedEdgeAccessor[i], edgeGroupMaskAccessor[i], subLaneGroupMaskAccessor[i]);
                   bool extraOptionsSupported = PredefinedPatternsProcessor.AreExtraOptionsSupported(edgeInfoArray);
                   bool exclusivePedestrianOptionSupported = PredefinedPatternsProcessor.IsExclusivePedestrianOptionSupported(edgeInfoArray);
                   var pattern = customTrafficLights.GetPattern();
@@ -261,6 +261,7 @@ public partial class PatchedTrafficLightInitializationSystem : Game.GameSystemBa
                   {
                       customTrafficLights.SetPattern(PredefinedPatternsProcessor.ClearExclusivePedestrianOption(pattern));
                   }
+                  NodeUtils.Dispose(edgeInfoArray);
                     if (customTrafficLights.GetPatternOnly() == CustomTrafficLights.Patterns.SplitPhasing)
                     {
                         PredefinedPatternsProcessor.SetupSplitPhasing(ref this, connectedEdgeAccessor[i], subLanes, out groupCount, ref trafficLights);

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.UIBIndings.cs
@@ -1350,13 +1350,17 @@ public partial class UISystem
             hasDecisionTrace,
             decisionTrace);
 
-        bool isNewSelection = false;
+        bool isNewHistory = false;
         if (!m_TspDiagnosticsEvents.TryGetValue(entity, out TspDiagnosticsHistory history))
         {
             history = new TspDiagnosticsHistory();
             m_TspDiagnosticsEvents[entity] = history;
-            isNewSelection = true;
+            isNewHistory = true;
         }
+
+        bool selectionChanged = m_TspDiagnosticsSelectedEntity != entity;
+        bool isNewSelection = selectionChanged || isNewHistory;
+        m_TspDiagnosticsSelectedEntity = entity;
 
         bool signatureChanged = history.LastSignature != signature;
         bool shouldRecordEvent = isNewSelection || (signatureChanged && ShouldRecordTspDiagnosticsEvent(history, hasRuntimeDebug || hasBusApproachDebug || hasDecisionTrace));

--- a/TrafficLightsEnhancement/Systems/UI/UISystem.cs
+++ b/TrafficLightsEnhancement/Systems/UI/UISystem.cs
@@ -75,6 +75,7 @@ public partial class UISystem: ExtendedUISystemBase
     private Dictionary<Entity, NativeArray<NodeUtils.EdgeInfo>> m_EdgeInfoDictionary;
 
     private Dictionary<Entity, TspDiagnosticsHistory> m_TspDiagnosticsEvents;
+    private Entity m_TspDiagnosticsSelectedEntity = Entity.Null;
 
     private int m_DebugDisplayGroup;
 
@@ -247,7 +248,7 @@ public partial class UISystem: ExtendedUISystemBase
         
         ClearEdgeInfo();
         
-        m_EdgeInfoDictionary[node] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, node, this).AsArray();
+        m_EdgeInfoDictionary[node] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, node, this);
         
         if (EntityManager.HasComponent<TrafficGroupMember>(node))
         {
@@ -267,7 +268,7 @@ public partial class UISystem: ExtendedUISystemBase
                         
                         if (hasPhases)
                         {
-                            m_EdgeInfoDictionary[memberEntity] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, memberEntity, this).AsArray();
+                            m_EdgeInfoDictionary[memberEntity] = NodeUtils.GetEdgeInfoList(Allocator.Persistent, memberEntity, this);
                         }
                     }
                 }
@@ -437,6 +438,7 @@ public partial class UISystem: ExtendedUISystemBase
                 {
                     SetMainPanelState(MainPanelState.Empty);
                 }
+                m_TspDiagnosticsSelectedEntity = Entity.Null;
                 m_SelectedEntity = entity;
             }
         }

--- a/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
+++ b/TrafficLightsEnhancement/UI/tests/transit-signal-priority-panel.test.mjs
@@ -520,6 +520,25 @@ test("backend trace writes follow selected diagnostics event filtering", async (
   assert.ok(eventsSource.indexOf("bool shouldRecordEvent") < eventsSource.indexOf("RecordTspDiagnosticsEvent"));
 });
 
+test("backend treats reselecting a previously tracked junction as a new diagnostics selection", async () => {
+  const uiBindings = await repoSource("Systems/UI/UISystem.UIBIndings.cs");
+  const uiSystem = await repoSource("Systems/UI/UISystem.cs");
+  const eventsStart = uiBindings.indexOf("private ArrayList GetTspDiagnosticsEvents");
+  const eventsEnd = uiBindings.indexOf("private void PruneTspDiagnosticsEvents", eventsStart);
+  const eventsSource = uiBindings.slice(eventsStart, eventsEnd);
+
+  assert.notEqual(eventsStart, -1);
+  assert.notEqual(eventsEnd, -1);
+  assert.match(uiSystem, /private\s+Entity\s+m_TspDiagnosticsSelectedEntity\s*=\s*Entity\.Null\s*;/);
+  assert.match(eventsSource, /bool\s+selectionChanged\s*=\s*m_TspDiagnosticsSelectedEntity\s*!=\s*entity\s*;/);
+  assert.match(eventsSource, /bool\s+isNewSelection\s*=\s*selectionChanged\s*\|\|\s*isNewHistory\s*;/);
+  assert.match(eventsSource, /m_TspDiagnosticsSelectedEntity\s*=\s*entity\s*;/);
+  assert.ok(
+    eventsSource.indexOf("bool isNewSelection") < eventsSource.indexOf("bool shouldRecordEvent"),
+    "selection-change state should feed trace event filtering"
+  );
+});
+
 test("selecting a junction for the first time forces an initial diagnostics trace write", async () => {
   const uiBindings = await repoSource("Systems/UI/UISystem.UIBIndings.cs");
   const eventsStart = uiBindings.indexOf("private ArrayList GetTspDiagnosticsEvents");
@@ -531,7 +550,23 @@ test("selecting a junction for the first time forces an initial diagnostics trac
   // A junction that is not yet tracked must be flagged as a new selection so the first
   // selection always writes an initial trace, even when the junction is idle (issue #114).
   assert.match(eventsSource, /if\s*\(\s*!m_TspDiagnosticsEvents\.TryGetValue\(\s*entity,\s*out\s+TspDiagnosticsHistory\s+history\s*\)\s*\)/);
-  assert.match(eventsSource, /m_TspDiagnosticsEvents\[entity\]\s*=\s*history;\s*isNewSelection\s*=\s*true;/);
+  assert.match(eventsSource, /m_TspDiagnosticsEvents\[entity\]\s*=\s*history;\s*isNewHistory\s*=\s*true;/);
+});
+
+test("backend owns generated edge info arrays instead of leaking native lists", async () => {
+  const nodeUtils = await repoSource("Utils/NodeUtils.cs");
+  const initializationSystem = await repoSource("Systems/TrafficLightSystems/Initialisation/PatchedTrafficLightInitializationSystem.cs");
+  const uiSystem = await repoSource("Systems/UI/UISystem.cs");
+
+  assert.match(nodeUtils, /public\s+static\s+NativeArray<EdgeInfo>\s+GetEdgeInfoList/);
+  assert.doesNotMatch(nodeUtils, /public\s+static\s+NativeList<EdgeInfo>\s+GetEdgeInfoList/);
+  assert.match(nodeUtils, /using\s+NativeList<EdgeInfo>\s+edgeInfoList\s*=\s*new\(4,\s*Allocator\.Temp\)/);
+  assert.match(nodeUtils, /edgeInfo\.m_SubLaneInfoList\s*=\s*new\s+NativeArray<SubLaneInfo>\(subLaneInfoList\.Length,\s*allocator\)/);
+  assert.match(nodeUtils, /var\s+edgeInfoArray\s*=\s*new\s+NativeArray<EdgeInfo>\(edgeInfoList\.Length,\s*allocator\)/);
+  assert.match(initializationSystem, /var\s+edgeInfoArray\s*=\s*NodeUtils\.GetEdgeInfoList\(Allocator\.Temp/);
+  assert.match(initializationSystem, /NodeUtils\.Dispose\(edgeInfoArray\)/);
+  assert.doesNotMatch(initializationSystem, /GetEdgeInfoList\([\s\S]*?\)\.AsArray\(\)/);
+  assert.doesNotMatch(uiSystem, /GetEdgeInfoList\([\s\S]*?\)\.AsArray\(\)/);
 });
 
 test("diagnostics trace logging is limited to the initial selection write", async () => {

--- a/TrafficLightsEnhancement/Utils/NodeUtils.cs
+++ b/TrafficLightsEnhancement/Utils/NodeUtils.cs
@@ -32,7 +32,7 @@ public partial struct NodeUtils
         }
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList
+    public static NativeArray<EdgeInfo> GetEdgeInfoList
     (
         Allocator allocator,
         Entity nodeEntity,
@@ -56,8 +56,8 @@ public partial struct NodeUtils
         ComponentLookup<CarLaneData> carLaneDataLookup
     )
     {
-        NativeList<EdgeInfo> edgeInfoList = new(4, allocator);
-        NativeHashMap<Entity, LaneConnection> laneConnectionMap = GetLaneConnectionMap(Allocator.Temp, nodeSubLaneBuffer, connectedEdgeBuffer, subLaneLookup, laneLookup);
+        using NativeList<EdgeInfo> edgeInfoList = new(4, Allocator.Temp);
+        using var laneConnectionMap = GetLaneConnectionMap(Allocator.Temp, nodeSubLaneBuffer, connectedEdgeBuffer, subLaneLookup, laneLookup);
 
         foreach (ConnectedEdge connectedEdge in connectedEdgeBuffer)
         {
@@ -69,8 +69,8 @@ public partial struct NodeUtils
             edgeInfo.m_Position = edgePosition;
             CustomPhaseUtils.TryGet(edgeGroupMaskBuffer, edgeEntity, edgePosition, out edgeInfo.m_EdgeGroupMask);
 
-            NativeHashMap<Entity, SubLaneInfo> subLaneMap = new(16, Allocator.Temp);
-            NativeList<SubLaneInfo> subLaneInfoList = new(16, allocator);
+            var subLaneMap = new NativeHashMap<Entity, SubLaneInfo>(16, Allocator.Temp);
+            using NativeList<SubLaneInfo> subLaneInfoList = new(16, Allocator.Temp);
 
             foreach (SubLane nodeSubLane in nodeSubLaneBuffer)
             {
@@ -197,14 +197,18 @@ public partial struct NodeUtils
                 CustomPhaseUtils.TryGet(subLaneGroupMaskBuffer, subLaneInfo.m_SubLane, subLaneInfo.m_Position, out subLaneInfo.m_SubLaneGroupMask);
                 subLaneInfoList.Add(subLaneInfo);
             }
-            edgeInfo.m_SubLaneInfoList = subLaneInfoList.AsArray();
+            edgeInfo.m_SubLaneInfoList = new NativeArray<SubLaneInfo>(subLaneInfoList.Length, allocator);
+            edgeInfo.m_SubLaneInfoList.CopyFrom(subLaneInfoList.AsArray());
             edgeInfoList.Add(edgeInfo);
+            subLaneMap.Dispose();
         }
 
-        return edgeInfoList;
+        var edgeInfoArray = new NativeArray<EdgeInfo>(edgeInfoList.Length, allocator);
+        edgeInfoArray.CopyFrom(edgeInfoList.AsArray());
+        return edgeInfoArray;
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, Systems.UI.UISystem uISystem)
+    public static NativeArray<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, Systems.UI.UISystem uISystem)
     {
         uISystem.m_TypeHandle.Update(uISystem);
         uISystem.m_TypeHandle.m_SubLane.TryGetBuffer(nodeEntity, out var nodeSubLaneBuffer);
@@ -236,7 +240,7 @@ public partial struct NodeUtils
         );
     }
 
-    public static NativeList<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, ref InitializeTrafficLightsJob job, DynamicBuffer<SubLane> nodeSubLaneBuffer, DynamicBuffer<ConnectedEdge> connectedEdgeBuffer, DynamicBuffer<EdgeGroupMask> edgeGroupMaskBuffer, DynamicBuffer<SubLaneGroupMask> subLaneGroupMaskBuffer)
+    public static NativeArray<EdgeInfo> GetEdgeInfoList(Allocator allocator, Entity nodeEntity, ref InitializeTrafficLightsJob job, DynamicBuffer<SubLane> nodeSubLaneBuffer, DynamicBuffer<ConnectedEdge> connectedEdgeBuffer, DynamicBuffer<EdgeGroupMask> edgeGroupMaskBuffer, DynamicBuffer<SubLaneGroupMask> subLaneGroupMaskBuffer)
     {
         return GetEdgeInfoList
         (


### PR DESCRIPTION
*Written by Codex.*

## Summary
- Fix TSP diagnostics event filtering so returning to a previously tracked junction is treated as a fresh selection for the initial trace write.
- Refactor selected-junction edge info collection to return owned `NativeArray<EdgeInfo>` data instead of leaking `NativeList`/`AsArray()` views.
- Dispose temporary initialization edge info arrays and clean up the xUnit collection-size assertion warning.

## Root Cause
`GetEdgeInfoList` returned `NativeList<EdgeInfo>` while callers stored or consumed `AsArray()` views, leaving the owning native lists undisposed in initialization. TSP diagnostics also treated only first-time history creation as a new selection, so A -> B -> A could skip the initial trace write for the reselected junction.

## Verification
- `npm.cmd test --prefix TrafficLightsEnhancement/UI` (53/53 passed)
- `dotnet test TrafficLightsEnhancement.Ecs.Tests/TrafficLightsEnhancement.Ecs.Tests.csproj -m:1 /p:BuildInParallel=false` (78/78 passed)
- `dotnet test TrafficLightsEnhancement.Tests/TrafficLightsEnhancement.Tests.csproj -m:1 /p:BuildInParallel=false` (185/185 passed)
- `git diff --cached --check` before commit