### PR TITLE
[codex] Harden save/load compatibility checks

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -11,7 +11,7 @@ You can use it to:
 - Build your own custom phase cycle.
 - Give trams or buses signal priority at selected intersections.
 
-The mod supports both left-hand traffic and right-hand traffic. It is also intended to keep existing Traffic Lights Enhancement intersection settings compatible when you load a city with TLE Extended; the README links to the maintainer checklist that tracks what is automated and what still needs release-time save/load evidence.
+The mod supports both left-hand traffic and right-hand traffic. It is also intended to keep existing Traffic Lights Enhancement intersection settings compatible when you load a city with TLE Extended; see the README for current compatibility notes and limitations.
 
 > [!TIP]
 > If a mode or option is missing, the selected intersection probably cannot use it. Try a simpler road junction, or use custom phases if you want to build the signal behavior yourself.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -11,7 +11,7 @@ You can use it to:
 - Build your own custom phase cycle.
 - Give trams or buses signal priority at selected intersections.
 
-The mod supports both left-hand traffic and right-hand traffic. It is also intended to keep existing Traffic Lights Enhancement intersection settings compatible when you load a city with TLE Extended.
+The mod supports both left-hand traffic and right-hand traffic. It is also intended to keep existing Traffic Lights Enhancement intersection settings compatible when you load a city with TLE Extended; the README links to the maintainer checklist that tracks what is automated and what still needs release-time save/load evidence.
 
 > [!TIP]
 > If a mode or option is missing, the selected intersection probably cannot use it. Try a simpler road junction, or use custom phases if you want to build the signal behavior yourself.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Compatibility with the current Cities: Skylines II version should be verified be
 
 TLE Extended is intended to be a drop-in replacement for Traffic Lights Enhancement. A city with intersections already configured in TLE should continue to load and preserve those intersection settings when switching to TLE Extended.
 
+The [save-format contract](docs/save-format-contract.md) tracks which compatibility cases are covered by automated serializer, migration, and policy tests, and which cases still need game-runtime fixture or smoke-test evidence before a public release.
+
 The mod stores extra data in saves to provide additional functionality. If the mod is removed, traffic lights and junctions should usually revert to default settings when a road update is triggered, but this cannot be guaranteed.
 
 You should not downgrade a save from TLE Extended to an older TLE build after saving with this fork. Cities saved with newer data may not be compatible with previous versions.

--- a/TrafficLightsEnhancement.Serialization.Tests/Serialization/InheritedComponentSerializationTests.cs
+++ b/TrafficLightsEnhancement.Serialization.Tests/Serialization/InheritedComponentSerializationTests.cs
@@ -65,6 +65,45 @@ public class InheritedComponentSerializationTests
     }
 
     [Fact]
+    public void Custom_traffic_lights_deserializes_v1_payload_as_vanilla()
+    {
+        var result = Deserialize<CustomTrafficLights>(writer =>
+        {
+            writer.Write(TLEDataVersion.V1);
+            for (int i = 1; i < 16; i++)
+            {
+                writer.Write((uint)CustomTrafficLights.Patterns.CustomPhase);
+            }
+        });
+
+        Assert.Equal(CustomTrafficLights.Patterns.Vanilla, result.GetPattern());
+        Assert.Equal(1f, result.m_PedestrianPhaseDurationMultiplier);
+        Assert.Equal(0, result.m_PedestrianPhaseGroupMask);
+        Assert.Equal(0u, result.m_Timer);
+        Assert.Equal((byte)0, result.m_ManualSignalGroup);
+        Assert.Equal(CustomTrafficLights.TrafficMode.Dynamic, result.GetMode());
+        Assert.Equal(CustomTrafficLights.TrafficOptions.SmartPhaseSelection, result.GetOptions());
+    }
+
+    [Fact]
+    public void Custom_traffic_lights_deserializes_v2_payload_with_default_later_fields()
+    {
+        var result = Deserialize<CustomTrafficLights>(writer =>
+        {
+            writer.Write(TLEDataVersion.V2);
+            writer.Write((uint)CustomTrafficLights.Patterns.SplitPhasing);
+        });
+
+        Assert.Equal(CustomTrafficLights.Patterns.SplitPhasing, result.GetPattern());
+        Assert.Equal(1f, result.m_PedestrianPhaseDurationMultiplier);
+        Assert.Equal(0, result.m_PedestrianPhaseGroupMask);
+        Assert.Equal(0u, result.m_Timer);
+        Assert.Equal((byte)0, result.m_ManualSignalGroup);
+        Assert.Equal(CustomTrafficLights.TrafficMode.Dynamic, result.GetMode());
+        Assert.Equal(CustomTrafficLights.TrafficOptions.SmartPhaseSelection, result.GetOptions());
+    }
+
+    [Fact]
     public void Transit_signal_priority_settings_round_trips_current_payload()
     {
         var source = TransitSignalPrioritySettings.CreateDefault();
@@ -100,6 +139,49 @@ public class InheritedComponentSerializationTests
         Assert.True(result.m_Enabled);
         Assert.False(result.m_AllowTrackRequests);
         Assert.True(result.m_AllowPublicCarRequests);
+        Assert.Equal(
+            global::TrafficLightsEnhancement.Logic.Tsp.TransitSignalPrioritySettings.DefaultRequestHorizonTicks,
+            result.m_RequestHorizonTicks);
+        Assert.Equal(
+            global::TrafficLightsEnhancement.Logic.Tsp.TransitSignalPrioritySettings.DefaultMaxGreenExtensionTicks,
+            result.m_MaxGreenExtensionTicks);
+    }
+
+    [Fact]
+    public void Transit_signal_priority_settings_deserializes_v2_payload_and_normalizes_upper_limits()
+    {
+        var result = Deserialize<TransitSignalPrioritySettings>(writer =>
+        {
+            writer.Write(2);
+            writer.Write(true);
+            writer.Write(false);
+            writer.Write(true);
+            writer.Write(ushort.MaxValue);
+            writer.Write(ushort.MaxValue);
+        });
+
+        Assert.True(result.m_Enabled);
+        Assert.False(result.m_AllowTrackRequests);
+        Assert.True(result.m_AllowPublicCarRequests);
+        Assert.Equal(
+            global::TrafficLightsEnhancement.Logic.Tsp.TransitSignalPrioritySettings.MaxRequestHorizonTicksUpperBound,
+            result.m_RequestHorizonTicks);
+        Assert.Equal(
+            global::TrafficLightsEnhancement.Logic.Tsp.TransitSignalPrioritySettings.MaxGreenExtensionTicksUpperBound,
+            result.m_MaxGreenExtensionTicks);
+    }
+
+    [Fact]
+    public void Transit_signal_priority_settings_deserializes_pre_v1_payload_as_defaults()
+    {
+        var result = Deserialize<TransitSignalPrioritySettings>(writer =>
+        {
+            writer.Write(0);
+        });
+
+        Assert.False(result.m_Enabled);
+        Assert.True(result.m_AllowTrackRequests);
+        Assert.False(result.m_AllowPublicCarRequests);
         Assert.Equal(
             global::TrafficLightsEnhancement.Logic.Tsp.TransitSignalPrioritySettings.DefaultRequestHorizonTicks,
             result.m_RequestHorizonTicks);

--- a/docs/save-format-contract.md
+++ b/docs/save-format-contract.md
@@ -174,3 +174,75 @@ TLE Extended should preserve these assumptions while in drop-in mode:
 Before changing any serialized field order, type, version, or normalization
 rule, add or update serializer fixtures in
 `TrafficLightsEnhancement.Serialization.Tests` and update this contract.
+
+## Save/Load Compatibility Checklist
+
+Use this checklist when changing serializers, migration jobs, save-facing UI
+bindings, traffic-group persistence, or TSP settings. Keep each row tied to
+automation or a named follow-up so compatibility remains an auditable claim.
+
+| Case | Current automated evidence | Status | Next action |
+| --- | --- | --- | --- |
+| Existing TLE intersections | `CustomTrafficLights` current round trip plus `V1`, `V2`, and `V4` legacy payload fixtures in `InheritedComponentSerializationTests`; migration sequencing for loaded versions `0..6` in `TleMigrationPlanTests`. | Partially automated | Add game-runtime load fixtures with representative upstream TLE saves before public release. |
+| TLE Extended-only data | `TransitSignalPrioritySettings` current round trip, TSP payload `1` fixture, pre-`V1` payload defaulting, and payload `2` normalization fixtures in `InheritedComponentSerializationTests`; TSP source/persistence policy coverage in `TspPolicyTests`. | Automated at serializer and policy level | Add a game-runtime save/load fixture proving Extended-only components survive a real save cycle. |
+| Traffic groups | `TrafficGroup` and `TrafficGroupMember` current round trips; `TrafficGroup` payload `V2` legacy-discard fixture; `TrafficGroupMember` payload `V1` defaulting fixture; signed phase-offset source guard in `TrafficGroupSystemSourceTests`; copy-missing-phases load-time source guard in `CopyPhasesToAllMembersSourceTests`. | Partially automated | Add ECS/world-level migration tests for invalid references, empty-group cleanup, and missing follower phases when a lightweight harness exists. |
+| Custom phases | `CustomPhaseData`, `EdgeGroupMask`, and `SubLaneGroupMask` current round trips; `CustomPhaseData` payload `V1`, `EdgeGroupMask` payload `V1`, and `GroupMask.Signal` payload `V1` fixtures; no-TSP custom-state-machine regression coverage in `CustomStateMachineNoTspRegressionTests`. | Automated at serializer and selected runtime-policy level | Add game-runtime fixture coverage for a saved custom-phase intersection with masks and timing settings. |
+| TSP settings | Serializer fixtures listed above; default, grouped-intersection, request-horizon, max-extension, public-car/bus, and approach-index policy coverage in `TspPolicyTests`; runtime-only TSP request/debug fields are excluded from the serialized payload list above. | Automated at serializer and policy level | Keep future source-flag or timing changes paired with payload-version notes and focused serializer fixtures. |
+| Downgrade and mod-removal limits | README and this contract warn that Extended saves are not downgrade-safe after Extended writes unknown components, and mod removal can only usually revert lights after road updates. | Documented limitation | Do not advertise downgrade or removal safety without a real downgrade/removal smoke-test playbook. |
+| Migration and normalization behavior | `TleMigrationPlanTests` covers global migration step selection; serializer fixtures cover legacy field defaults and TSP normalization; source guards cover selected validation invariants. | Partially automated | Add ECS/world-level tests for validation jobs that repair or remove invalid loaded data. |
+
+### Follow-Up Issue Drafts
+
+Use these draft bodies if the missing coverage needs to be tracked publicly.
+When opening them, apply the repository's required agent-work, priority, area,
+and project metadata.
+
+#### Add game-runtime save/load fixtures for TLE compatibility
+
+*Written by Codex.*
+
+Add a small game-runtime or harness-backed save/load fixture set that proves the
+compatibility cases currently covered only by serializer-level tests:
+
+- an upstream TLE save with predefined signal options,
+- an upstream TLE save with custom phases and group masks,
+- a TLE Extended save with `TransitSignalPrioritySettings`,
+- a traffic-group save with leader/member metadata.
+
+The test should load the fixture, assert the expected ECS components and values,
+save again, reload, and assert the same values. Keep fixture documentation in
+`docs/save-format-contract.md`.
+
+#### Add downgrade and mod-removal compatibility smoke tests
+
+*Written by Codex.*
+
+Create a manual or automated smoke-test playbook for the downgrade/removal
+limits documented in `README.md` and `docs/save-format-contract.md`.
+
+Cover:
+
+- loading a TLE Extended save in the intended current build,
+- attempting to load or inspect the same save with an older upstream TLE build,
+- removing the mod and triggering a road update at previously configured
+  intersections,
+- recording exactly which data is preserved, reset, ignored, or unsafe.
+
+Do not upgrade the README claim beyond the observed results.
+
+#### Add ECS validation coverage for loaded-data repair jobs
+
+*Written by Codex.*
+
+Add focused ECS or harness tests for the validation behavior in
+`TLEDataMigrationSystem` and `TLEDataMigrationJobs`:
+
+- invalid `SignalDelayData` edges are removed and delays clamp to `0..300`,
+- invalid `TrafficGroupMember` references are removed or reset,
+- invalid `TrafficGroup` timing values reset to defaults,
+- invalid `CustomTrafficLights` values reset and record affected intersections,
+- orphaned custom phase or mask buffers recreate default `CustomTrafficLights`
+  so the user can inspect and repair them.
+
+These tests should complement the existing serializer fixtures and migration
+plan tests rather than replacing them.


### PR DESCRIPTION
*Written by Codex.*

## Summary
- Add a save/load compatibility checklist to the save-format contract, mapping automated evidence and remaining game-runtime gaps for TLE, TLE Extended, traffic groups, custom phases, TSP settings, downgrade/removal limits, and migration behavior.
- Add exact follow-up issue draft bodies for missing game-runtime, downgrade/removal, and ECS validation coverage.
- Tighten README and guide compatibility wording, and add focused serialization fixtures for legacy `CustomTrafficLights` payloads plus TSP deserialization normalization/default behavior.

## Review evidence
- Internal Codex subagent review checked the uncommitted issue #141 diff and found one wording precision issue around TSP pre-`V1` payload defaulting.
- The wording issue was fixed before the branch commit. A final independent review should be run against the pushed branch tip before marking this PR ready.

## Test plan
- `dotnet test TrafficLightsEnhancement.Serialization.Tests/TrafficLightsEnhancement.Serialization.Tests.csproj` - 27 passed, 0 failed
- `git diff --check` - clean aside from Windows line-ending normalization warnings

Closes #141